### PR TITLE
feat: add unit tests for Credfeto.Package.Update to achieve 100% coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 - Suppress NuGet.Protocol 6.14.0 low severity vulnerability GHSA-g4vj-cjjj-v7hg pending package update
 ### Added
+- Unit tests for Credfeto.Package.Update to achieve 100% code coverage
 ### Fixed
 - Remove tracked JetBrains IDE files (.idea) that were committed despite being gitignored
 - Add missing YAML document start marker to GitVersion.yml for ansible-lint compliance

--- a/src/Credfeto.Package.Update.Tests/ApplicationSetupTests.cs
+++ b/src/Credfeto.Package.Update.Tests/ApplicationSetupTests.cs
@@ -1,0 +1,55 @@
+using System;
+using FunFair.Test.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests;
+
+public sealed class ApplicationSetupTests : TestBase
+{
+    [Fact]
+    public void SetupWithWarningsAsErrorsFalseReturnsNonNullServiceProvider()
+    {
+        IServiceProvider serviceProvider = ApplicationSetup.Setup(warningsAsErrors: false);
+
+        Assert.NotNull(serviceProvider);
+    }
+
+    [Fact]
+    public void SetupWithWarningsAsErrorsTrueReturnsNonNullServiceProvider()
+    {
+        IServiceProvider serviceProvider = ApplicationSetup.Setup(warningsAsErrors: true);
+
+        Assert.NotNull(serviceProvider);
+    }
+
+    [Fact]
+    public void SetupWithWarningsAsErrorsFalseCanResolveDiagnosticLogger()
+    {
+        IServiceProvider serviceProvider = ApplicationSetup.Setup(warningsAsErrors: false);
+
+        IDiagnosticLogger diagnosticLogger = serviceProvider.GetRequiredService<IDiagnosticLogger>();
+
+        Assert.NotNull(diagnosticLogger);
+    }
+
+    [Fact]
+    public void SetupWithWarningsAsErrorsFalseCanResolvePackageUpdater()
+    {
+        IServiceProvider serviceProvider = ApplicationSetup.Setup(warningsAsErrors: false);
+
+        IPackageUpdater packageUpdater = serviceProvider.GetRequiredService<IPackageUpdater>();
+
+        Assert.NotNull(packageUpdater);
+    }
+
+    [Fact]
+    public void SetupWithWarningsAsErrorsFalseCanResolvePackageCache()
+    {
+        IServiceProvider serviceProvider = ApplicationSetup.Setup(warningsAsErrors: false);
+
+        IPackageCache packageCache = serviceProvider.GetRequiredService<IPackageCache>();
+
+        Assert.NotNull(packageCache);
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj
+++ b/src/Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj
@@ -1,59 +1,40 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <Authors>Mark Ridgwell</Authors>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <Company>Mark Ridgwell</Company>
-    <Copyright>Mark Ridgwell</Copyright>
     <DebuggerSupport>true</DebuggerSupport>
-    <Description>Scriptable update package tool</Description>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnablePackageValidation>true</EnablePackageValidation>
-    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
     <Features>strict;flow-analysis</Features>
     <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
-    <GenerateSBOM>true</GenerateSBOM>
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>
     <ImplicitUsings>disable</ImplicitUsings>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IsPackable>true</IsPackable>
-    <IsPublishable>true</IsPublishable>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <LangVersion>latest</LangVersion>
-    <NeutralLanguage>en-GB</NeutralLanguage>
     <NuGetAudit>true</NuGetAudit>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
-    <NuGetAuditMode>direct</NuGetAuditMode>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
     <Nullable>enable</Nullable>
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
-    <PackAsTool>true</PackAsTool>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
-    <PackageTags>Nuget;update;tool;packages</PackageTags>
-    <Product>Package Update Tool</Product>
-    <PublishAot>false</PublishAot>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-package-update</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
-    <ToolCommandName>updatepackages</ToolCommandName>
-    <TreatSpecificWarningsAsErrors />
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <ValidateExecutableReferencesMatchSelfContained>true</ValidateExecutableReferencesMatchSelfContained>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
@@ -66,30 +47,25 @@
     <!-- Error NU1903 : Warning As Error: Package 'System.Formats.Asn1' 6.0.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-447r-wph3-92pm" />
   </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')"/>
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Credfeto.Package.Update.Tests</_Parameter1>
-    </AssemblyAttribute>
+    <ProjectReference Include="..\Credfeto.Package.Update\Credfeto.Package.Update.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Credfeto.Package\Credfeto.Package.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Credfeto.Enumeration.Source.Generation.Attributes" Version="1.2.129.1430" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.4.1830" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.129.1430" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.115.836" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.24.1452" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.4.1830" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.219" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.6.4" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="1.9.1" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.14.0" PrivateAssets="All" ExcludeAssets="runtime" />
@@ -98,5 +74,6 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.25.0" PrivateAssets="All" ExcludeAssets="runtime" />
   </ItemGroup>
 </Project>

--- a/src/Credfeto.Package.Update.Tests/EnumExtensionsTests.cs
+++ b/src/Credfeto.Package.Update.Tests/EnumExtensionsTests.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using CommandLine;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests;
+
+public sealed class EnumExtensionsTests : TestBase
+{
+    [Theory]
+    [InlineData(LogLevel.Trace, "Trace")]
+    [InlineData(LogLevel.Debug, "Debug")]
+    [InlineData(LogLevel.Information, "Information")]
+    [InlineData(LogLevel.Warning, "Warning")]
+    [InlineData(LogLevel.Error, "Error")]
+    [InlineData(LogLevel.Critical, "Critical")]
+    [InlineData(LogLevel.None, "None")]
+    public void LogLevelGetNameReturnsExpectedString(LogLevel logLevel, string expected)
+    {
+        string result = logLevel.GetName();
+
+        Assert.Equal(expected: expected, actual: result);
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    [InlineData(LogLevel.None)]
+    public void LogLevelGetDescriptionReturnsNonEmptyString(LogLevel value)
+    {
+        string description = value.GetDescription();
+
+        Assert.NotEmpty(description);
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    [InlineData(LogLevel.None)]
+    public void LogLevelIsDefinedReturnsTrueForKnownValues(LogLevel value)
+    {
+        bool defined = value.IsDefined();
+
+        Assert.True(defined, userMessage: "Expected IsDefined to return true for a known LogLevel value");
+    }
+
+    [Fact]
+    public void LogLevelIsDefinedReturnsFalseForUnknownValue()
+    {
+        bool defined = ((LogLevel)int.MaxValue).IsDefined();
+
+        Assert.False(defined, userMessage: "Expected IsDefined to return false for an unknown LogLevel value");
+    }
+
+    [Fact]
+    public void LogLevelGetNameThrowsForUnknownValue()
+    {
+        Assert.Throws<UnreachableException>(() => ((LogLevel)int.MaxValue).GetName());
+    }
+
+    [Theory]
+    [InlineData(ErrorType.BadFormatTokenError, "BadFormatTokenError")]
+    [InlineData(ErrorType.MissingValueOptionError, "MissingValueOptionError")]
+    [InlineData(ErrorType.UnknownOptionError, "UnknownOptionError")]
+    [InlineData(ErrorType.MissingRequiredOptionError, "MissingRequiredOptionError")]
+    [InlineData(ErrorType.MutuallyExclusiveSetError, "MutuallyExclusiveSetError")]
+    [InlineData(ErrorType.BadFormatConversionError, "BadFormatConversionError")]
+    [InlineData(ErrorType.SequenceOutOfRangeError, "SequenceOutOfRangeError")]
+    [InlineData(ErrorType.RepeatedOptionError, "RepeatedOptionError")]
+    [InlineData(ErrorType.NoVerbSelectedError, "NoVerbSelectedError")]
+    [InlineData(ErrorType.BadVerbSelectedError, "BadVerbSelectedError")]
+    [InlineData(ErrorType.HelpRequestedError, "HelpRequestedError")]
+    [InlineData(ErrorType.HelpVerbRequestedError, "HelpVerbRequestedError")]
+    [InlineData(ErrorType.VersionRequestedError, "VersionRequestedError")]
+    [InlineData(ErrorType.SetValueExceptionError, "SetValueExceptionError")]
+    [InlineData(ErrorType.InvalidAttributeConfigurationError, "InvalidAttributeConfigurationError")]
+    [InlineData(ErrorType.MissingGroupOptionError, "MissingGroupOptionError")]
+    [InlineData(ErrorType.GroupOptionAmbiguityError, "GroupOptionAmbiguityError")]
+    [InlineData(ErrorType.MultipleDefaultVerbsError, "MultipleDefaultVerbsError")]
+    public void ErrorTypeGetNameReturnsExpectedString(ErrorType errorType, string expected)
+    {
+        string result = errorType.GetName();
+
+        Assert.Equal(expected: expected, actual: result);
+    }
+
+    [Theory]
+    [InlineData(ErrorType.BadFormatTokenError)]
+    [InlineData(ErrorType.MissingValueOptionError)]
+    [InlineData(ErrorType.UnknownOptionError)]
+    [InlineData(ErrorType.MissingRequiredOptionError)]
+    [InlineData(ErrorType.MutuallyExclusiveSetError)]
+    [InlineData(ErrorType.BadFormatConversionError)]
+    [InlineData(ErrorType.SequenceOutOfRangeError)]
+    [InlineData(ErrorType.RepeatedOptionError)]
+    [InlineData(ErrorType.NoVerbSelectedError)]
+    [InlineData(ErrorType.BadVerbSelectedError)]
+    [InlineData(ErrorType.HelpRequestedError)]
+    [InlineData(ErrorType.HelpVerbRequestedError)]
+    [InlineData(ErrorType.VersionRequestedError)]
+    [InlineData(ErrorType.SetValueExceptionError)]
+    [InlineData(ErrorType.InvalidAttributeConfigurationError)]
+    [InlineData(ErrorType.MissingGroupOptionError)]
+    [InlineData(ErrorType.GroupOptionAmbiguityError)]
+    [InlineData(ErrorType.MultipleDefaultVerbsError)]
+    public void ErrorTypeGetDescriptionReturnsNonEmptyString(ErrorType value)
+    {
+        string description = value.GetDescription();
+
+        Assert.NotEmpty(description);
+    }
+
+    [Theory]
+    [InlineData(ErrorType.BadFormatTokenError)]
+    [InlineData(ErrorType.MissingValueOptionError)]
+    [InlineData(ErrorType.UnknownOptionError)]
+    [InlineData(ErrorType.MissingRequiredOptionError)]
+    [InlineData(ErrorType.MutuallyExclusiveSetError)]
+    [InlineData(ErrorType.BadFormatConversionError)]
+    [InlineData(ErrorType.SequenceOutOfRangeError)]
+    [InlineData(ErrorType.RepeatedOptionError)]
+    [InlineData(ErrorType.NoVerbSelectedError)]
+    [InlineData(ErrorType.BadVerbSelectedError)]
+    [InlineData(ErrorType.HelpRequestedError)]
+    [InlineData(ErrorType.HelpVerbRequestedError)]
+    [InlineData(ErrorType.VersionRequestedError)]
+    [InlineData(ErrorType.SetValueExceptionError)]
+    [InlineData(ErrorType.InvalidAttributeConfigurationError)]
+    [InlineData(ErrorType.MissingGroupOptionError)]
+    [InlineData(ErrorType.GroupOptionAmbiguityError)]
+    [InlineData(ErrorType.MultipleDefaultVerbsError)]
+    public void ErrorTypeIsDefinedReturnsTrueForKnownValues(ErrorType value)
+    {
+        bool defined = value.IsDefined();
+
+        Assert.True(defined, userMessage: "Expected IsDefined to return true for a known ErrorType value");
+    }
+
+    [Fact]
+    public void ErrorTypeIsDefinedReturnsFalseForUnknownValue()
+    {
+        bool defined = ((ErrorType)int.MaxValue).IsDefined();
+
+        Assert.False(defined, userMessage: "Expected IsDefined to return false for an unknown ErrorType value");
+    }
+
+    [Fact]
+    public void ErrorTypeGetNameThrowsForUnknownValue()
+    {
+        Assert.Throws<UnreachableException>(() => ((ErrorType)int.MaxValue).GetName());
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Exceptions/InvalidOptionsExceptionTests.cs
+++ b/src/Credfeto.Package.Update.Tests/Exceptions/InvalidOptionsExceptionTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Credfeto.Package.Update.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests.Exceptions;
+
+public sealed class InvalidOptionsExceptionTests : TestBase
+{
+    private const string TEST_MESSAGE = "Test exception message";
+
+    [Fact]
+    public void DefaultConstructorCreatesException()
+    {
+        InvalidOptionsException exception = new();
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        InvalidOptionsException exception = new(TEST_MESSAGE);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessageAndInnerException()
+    {
+        InvalidOptionsException innerException = new("Inner exception");
+        InvalidOptionsException exception = new(message: TEST_MESSAGE, innerException: innerException);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+        Assert.Same(expected: innerException, actual: exception.InnerException);
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Exceptions/NoPackagesUpdatedExceptionTests.cs
+++ b/src/Credfeto.Package.Update.Tests/Exceptions/NoPackagesUpdatedExceptionTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Credfeto.Package.Update.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests.Exceptions;
+
+public sealed class NoPackagesUpdatedExceptionTests : TestBase
+{
+    private const string TEST_MESSAGE = "Test exception message";
+
+    [Fact]
+    public void DefaultConstructorCreatesException()
+    {
+        NoPackagesUpdatedException exception = new();
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        NoPackagesUpdatedException exception = new(TEST_MESSAGE);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessageAndInnerException()
+    {
+        NoPackagesUpdatedException innerException = new("Inner exception");
+        NoPackagesUpdatedException exception = new(message: TEST_MESSAGE, innerException: innerException);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+        Assert.Same(expected: innerException, actual: exception.InnerException);
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Exceptions/PackageUpdateExceptionTests.cs
+++ b/src/Credfeto.Package.Update.Tests/Exceptions/PackageUpdateExceptionTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Credfeto.Package.Update.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests.Exceptions;
+
+public sealed class PackageUpdateExceptionTests : TestBase
+{
+    private const string TEST_MESSAGE = "Test exception message";
+
+    [Fact]
+    public void DefaultConstructorCreatesException()
+    {
+        PackageUpdateException exception = new();
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        PackageUpdateException exception = new(TEST_MESSAGE);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessageAndInnerException()
+    {
+        PackageUpdateException innerException = new("Inner exception");
+        PackageUpdateException exception = new(message: TEST_MESSAGE, innerException: innerException);
+
+        Assert.Equal(expected: TEST_MESSAGE, actual: exception.Message);
+        Assert.Same(expected: innerException, actual: exception.InnerException);
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Services/DiagnosticLoggerTests.cs
+++ b/src/Credfeto.Package.Update.Tests/Services/DiagnosticLoggerTests.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using Credfeto.Package.Update.Services;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests.Services;
+
+public sealed class DiagnosticLoggerTests : TestBase
+{
+    private const string TEST_MESSAGE = "Test log message";
+
+    private static Func<string, Exception?, string> SimpleFormatter => static (state, _) => state;
+
+    [Fact]
+    public void ErrorsIsZeroInitially()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+    }
+
+    [Fact]
+    public void IsErroredIsFalseInitially()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        Assert.False(logger.IsErrored, "IsErrored should be false when no errors have been logged");
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace, true)]
+    [InlineData(LogLevel.Debug, false)]
+    [InlineData(LogLevel.Information, true)]
+    [InlineData(LogLevel.Warning, true)]
+    [InlineData(LogLevel.Error, true)]
+    [InlineData(LogLevel.Critical, true)]
+    [InlineData(LogLevel.None, true)]
+    public void IsEnabledReturnsExpectedResultForLogLevel(LogLevel logLevel, bool expected)
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        Assert.Equal(expected: expected, actual: logger.IsEnabled(logLevel));
+    }
+
+    [Fact]
+    public void BeginScopeReturnsNonNullDisposable()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        IDisposable? scope = logger.BeginScope(state: "test scope");
+
+        Assert.NotNull(scope);
+    }
+
+    [Fact]
+    public void BeginScopeCanBeDisposedWithoutError()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        using IDisposable? scope = logger.BeginScope(state: "test scope");
+
+        Assert.NotNull(scope);
+    }
+
+    [Fact]
+    public void LogInformationDoesNotIncrementErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Information,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+        Assert.False(logger.IsErrored, "IsErrored should be false after logging information");
+    }
+
+    [Fact]
+    public void LogWarningWithoutWarningsAsErrorsDoesNotIncrementErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Warning,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+        Assert.False(
+            logger.IsErrored,
+            "IsErrored should be false after logging a warning when warningsAsErrors is false"
+        );
+    }
+
+    [Fact]
+    public void LogWarningWithWarningsAsErrorsIncrementsErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: true);
+
+        logger.Log(
+            logLevel: LogLevel.Warning,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 1, actual: logger.Errors);
+        Assert.True(logger.IsErrored, "IsErrored should be true after logging a warning when warningsAsErrors is true");
+    }
+
+    [Fact]
+    public void LogErrorIncrementsErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Error,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 1, actual: logger.Errors);
+        Assert.True(logger.IsErrored, "IsErrored should be true after logging an error");
+    }
+
+    [Fact]
+    public void LogCriticalIncrementsErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Critical,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 1, actual: logger.Errors);
+        Assert.True(logger.IsErrored, "IsErrored should be true after logging a critical message");
+    }
+
+    [Fact]
+    public void LogDebugDoesNotIncrementErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Debug,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+        Assert.False(logger.IsErrored, "IsErrored should be false after logging debug message");
+    }
+
+    [Fact]
+    public void LogErrorWithExceptionIncrementsErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+        InvalidOperationException exception = new("Something went wrong");
+
+        logger.Log(
+            logLevel: LogLevel.Error,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: exception,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 1, actual: logger.Errors);
+        Assert.True(logger.IsErrored, "IsErrored should be true after logging an error with exception");
+    }
+
+    [Fact]
+    public void MultipleErrorsAccumulate()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Error,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+        logger.Log(
+            logLevel: LogLevel.Critical,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 2, actual: logger.Errors);
+    }
+
+    [Fact]
+    public void LogTraceDoesNotIncrementErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.Trace,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+        Assert.False(logger.IsErrored, "IsErrored should be false after logging a trace message");
+    }
+
+    [Fact]
+    public void LogNoneDoesNotIncrementErrors()
+    {
+        DiagnosticLogger logger = new(warningsAsErrors: false);
+
+        logger.Log(
+            logLevel: LogLevel.None,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        Assert.Equal(expected: 0, actual: logger.Errors);
+        Assert.False(logger.IsErrored, "IsErrored should be false after logging with None level");
+    }
+}

--- a/src/Credfeto.Package.Update.Tests/Services/LoggerProxyTests.cs
+++ b/src/Credfeto.Package.Update.Tests/Services/LoggerProxyTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Credfeto.Package.Update.Services;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.Package.Update.Tests.Services;
+
+public sealed class LoggerProxyTests : TestBase
+{
+    private const string TEST_MESSAGE = "Test log message";
+
+    private static Func<string, Exception?, string> SimpleFormatter => static (state, _) => state;
+
+    [Fact]
+    public void ConstructorWithNullLoggerThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LoggerProxy<LoggerProxyTests>(null!));
+    }
+
+    [Fact]
+    public void IsEnabledDelegatesToInnerLogger()
+    {
+        ILogger innerLogger = GetSubstitute<ILogger>();
+        innerLogger.IsEnabled(LogLevel.Information).Returns(true);
+
+        LoggerProxy<LoggerProxyTests> proxy = new(innerLogger);
+
+        bool result = proxy.IsEnabled(LogLevel.Information);
+
+        Assert.True(result, "IsEnabled should return the value from the inner logger");
+        innerLogger.Received(1).IsEnabled(LogLevel.Information);
+    }
+
+    [Fact]
+    public void BeginScopeDelegatesToInnerLogger()
+    {
+        ILogger innerLogger = GetSubstitute<ILogger>();
+        IDisposable expectedScope = GetSubstitute<IDisposable>();
+        innerLogger.BeginScope(Arg.Any<string>()).Returns(expectedScope);
+
+        LoggerProxy<LoggerProxyTests> proxy = new(innerLogger);
+
+        using IDisposable? result = proxy.BeginScope(state: "test scope");
+
+        Assert.Same(expected: expectedScope, actual: result);
+        _ = innerLogger.Received(1).BeginScope(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void LogDelegatesToInnerLogger()
+    {
+        ILogger innerLogger = GetSubstitute<ILogger>();
+
+        LoggerProxy<LoggerProxyTests> proxy = new(innerLogger);
+
+        proxy.Log(
+            logLevel: LogLevel.Information,
+            eventId: default,
+            state: TEST_MESSAGE,
+            exception: null,
+            formatter: SimpleFormatter
+        );
+
+        innerLogger
+            .Received(1)
+            .Log(
+                logLevel: LogLevel.Information,
+                eventId: default,
+                state: TEST_MESSAGE,
+                exception: null,
+                formatter: SimpleFormatter
+            );
+    }
+}

--- a/src/Credfeto.Package.Update.slnx
+++ b/src/Credfeto.Package.Update.slnx
@@ -8,5 +8,6 @@
   </Folder>
   <Project Path="Credfeto.Package.Test/Credfeto.Package.Test.csproj" />
   <Project Path="Credfeto.Package.Update/Credfeto.Package.Update.csproj" />
+  <Project Path="Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj" />
   <Project Path="Credfeto.Package/Credfeto.Package.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

- Creates new test project `Credfeto.Package.Update.Tests` with 236 passing unit tests (net9.0 and net10.0)
- Covers all hand-written classes at 100%: `DiagnosticLogger`, `LoggerProxy`, `ApplicationSetup`, all three exception classes, and all generated `EnumExtensions` methods (`GetName`/`GetDescription`/`IsDefined` for `ErrorType` and `LogLevel`)
- Adds `InternalsVisibleTo` to `Credfeto.Package.Update.csproj` to allow test access to `ApplicationSetup` (internal)
- Fixes pre-existing `buildcheck` failure by adding `<PublishAot>false</PublishAot>` to `Credfeto.Package.Update.csproj`
- `Program.cs` remains at 0% — all its methods are `private static` in an `internal` class; unit testing them is not possible without integration tests

Closes #542