### PR TITLE
fix: skip PackageReference and SDK entries with unparseable version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Remove tracked JetBrains IDE files (.idea) that were committed despite being gitignored
 - Add missing YAML document start marker to GitVersion.yml for ansible-lint compliance
 - CI workflow fixes: add checkout before local actions, skip SOURCE_PUSH_TOKEN-dependent jobs for Dependabot PRs
+- Prevent crash when a PackageReference or SDK version attribute contains an unparseable value such as an MSBuild property, version range, or floating version
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/Services/ProjectTests.cs
+++ b/src/Credfeto.Package.Tests/Services/ProjectTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Credfeto.Package.Services;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Credfeto.Package.Tests.Services;
+
+public sealed class ProjectTests : LoggingFolderCleanupTestBase
+{
+    public ProjectTests(ITestOutputHelper output)
+        : base(output) { }
+
+    private ProjectLoader CreateLoader()
+    {
+        ILogger<ProjectLoader> logger = this.GetTypedLogger<ProjectLoader>();
+
+        return new ProjectLoader(logger);
+    }
+
+    private async Task<IProject?> LoadProjectAsync(string content)
+    {
+        string path = Path.Combine(this.TempFolder, "Test.csproj");
+        await File.WriteAllTextAsync(path: path, contents: content, cancellationToken: this.CancellationToken());
+
+        return await this.CreateLoader().LoadAsync(path: path, cancellationToken: this.CancellationToken());
+    }
+
+    [Fact]
+    public async Task Packages_WhenPackageReferenceHasMsBuildPropertyVersion_ReturnsEmpty()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        Assert.Empty(project.Packages);
+    }
+
+    [Fact]
+    public async Task Packages_WhenPackageReferenceHasVersionRange_ReturnsEmpty()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="[1.2.3,2.0.0)" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        Assert.Empty(project.Packages);
+    }
+
+    [Fact]
+    public async Task Packages_WhenPackageReferenceHasFloatingVersion_ReturnsEmpty()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="1.0.*" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        Assert.Empty(project.Packages);
+    }
+
+    [Fact]
+    public async Task Packages_WhenValidPackageReferenceAlongsideInvalidOne_ReturnsOnlyValid()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Valid.Package" Version="2.3.4" />
+                <PackageReference Include="Invalid.Package" Version="$(SomeVersion)" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        PackageVersion entry = Assert.Single(project.Packages);
+        Assert.Equal(expected: "Valid.Package", actual: entry.PackageId);
+        Assert.Equal(expected: new NuGetVersion("2.3.4"), actual: entry.Version);
+    }
+
+    [Fact]
+    public async Task Packages_WhenSdkAttributeHasUnparseableVersion_ReturnsEmpty()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Some.Sdk/$(SdkVersion)">
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        Assert.Empty(project.Packages);
+    }
+
+    [Fact]
+    public async Task Packages_WhenSdkAttributeHasValidVersion_ReturnsSdkPackage()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Some.Sdk/1.2.3">
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        PackageVersion entry = Assert.Single(project.Packages);
+        Assert.Equal(expected: "Some.Sdk", actual: entry.PackageId);
+        Assert.Equal(expected: new NuGetVersion("1.2.3"), actual: entry.Version);
+    }
+}

--- a/src/Credfeto.Package/Services/Project.cs
+++ b/src/Credfeto.Package/Services/Project.cs
@@ -174,7 +174,12 @@ internal sealed class Project : IProject
                 continue;
             }
 
-            yield return new(packageId: packageId, new(version));
+            if (!NuGetVersion.TryParse(value: version, out NuGetVersion? parsedVersion))
+            {
+                continue;
+            }
+
+            yield return new(packageId: packageId, parsedVersion);
         }
     }
 
@@ -187,9 +192,9 @@ internal sealed class Project : IProject
 
         IReadOnlyList<string> sdk = project.GetAttribute("Sdk").Split("/");
 
-        if (sdk.Count == 2)
+        if (sdk.Count == 2 && NuGetVersion.TryParse(value: sdk[1], out NuGetVersion? parsedVersion))
         {
-            yield return new(sdk[0], new(sdk[1]));
+            yield return new(sdk[0], parsedVersion);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace the throwing `NuGetVersion(string)` constructor with `NuGetVersion.TryParse` in both `GetPackagesFromReferences` and `GetPackagesFromSdk` in `Project.cs`
- Entries whose version string does not parse (MSBuild properties like `$(SomeVersion)`, version ranges like `[1.2.3,2.0.0)`, floating versions like `1.0.*`) are now silently skipped
- Matches the existing behaviour of `ShouldUpdate`, which already used `TryParse`
- Added `ProjectTests.cs` with six unit tests covering all three invalid version forms plus the SDK variant

## Test plan

- [ ] All 400 tests pass (verified locally, both net9.0 and net10.0)
- [ ] `ProjectTests.Packages_WhenPackageReferenceHasMsBuildPropertyVersion_ReturnsEmpty` — MSBuild property version skipped
- [ ] `ProjectTests.Packages_WhenPackageReferenceHasVersionRange_ReturnsEmpty` — version range skipped
- [ ] `ProjectTests.Packages_WhenPackageReferenceHasFloatingVersion_ReturnsEmpty` — floating version skipped
- [ ] `ProjectTests.Packages_WhenValidPackageReferenceAlongsideInvalidOne_ReturnsOnlyValid` — mixed entries return only the valid one
- [ ] `ProjectTests.Packages_WhenSdkAttributeHasUnparseableVersion_ReturnsEmpty` — SDK with property version skipped
- [ ] `ProjectTests.Packages_WhenSdkAttributeHasValidVersion_ReturnsSdkPackage` — SDK with valid version returned

Closes #566