### PR TITLE
fix: avoid full registry re-query on partial package cache miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add missing YAML document start marker to GitVersion.yml for ansible-lint compliance
 - CI workflow fixes: add checkout before local actions, skip SOURCE_PUSH_TOKEN-dependent jobs for Dependabot PRs
 - Prevent crash when a PackageReference or SDK version attribute contains an unparseable value such as an MSBuild property, version range, or floating version
+- Avoid re-querying the registry for every package when only some package ids are missing from the version cache
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/Services/PackageUpdaterTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageUpdaterTests.cs
@@ -181,6 +181,69 @@ public sealed class PackageUpdaterTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task UpdateAsync_WithMatchingPackages_WhenCacheHasPartialVersions_OnlyQueriesRegistryForMissingPackages()
+    {
+        await this.CreateDummyCsprojAsync();
+
+        PackageVersion cachedInstalledVersion = new(packageId: "test.cached", version: new NuGetVersion("1.0.0"));
+        PackageVersion cachedVersion = new(packageId: "test.cached", version: new NuGetVersion("1.0.0"));
+        PackageVersion missingInstalledVersion = new(packageId: "test.missing", version: new NuGetVersion("1.0.0"));
+        PackageVersion fetchedVersion = new(packageId: "test.missing", version: new NuGetVersion("2.0.0"));
+
+        IProject mockProject = GetSubstitute<IProject>();
+        mockProject.Packages.Returns([cachedInstalledVersion, missingInstalledVersion]);
+        mockProject.UpdatePackage(Arg.Any<PackageVersion>()).Returns(true);
+        mockProject.Changed.Returns(true);
+
+        IPackageCache packageCache = GetSubstitute<IPackageCache>();
+        packageCache.GetVersions(Arg.Any<IReadOnlyList<string>>()).Returns([cachedVersion]);
+
+        IPackageRegistry packageRegistry = GetSubstitute<IPackageRegistry>();
+        packageRegistry
+            .FindPackagesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([fetchedVersion]);
+
+        PackageUpdater updater = this.CreateUpdater(
+            projectLoader: new StaticProjectLoader(mockProject),
+            packageRegistry: packageRegistry,
+            packageCache: packageCache
+        );
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "test", Prefix: true),
+            ExcludedPackages: []
+        );
+
+        IReadOnlyList<PackageVersion> result = await updater.UpdateAsync(
+            basePath: this.TempFolder,
+            configuration: config,
+            packageSources: NO_PACKAGE_SOURCES,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Single(result);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: result[0].Version);
+        Assert.True(
+            StringComparer.OrdinalIgnoreCase.Equals(x: "test.missing", y: result[0].PackageId),
+            userMessage: "Package ID should match"
+        );
+
+        await packageRegistry
+            .Received(1)
+            .FindPackagesAsync(
+                Arg.Is<IReadOnlyList<string>>(ids =>
+                    ids.Count == 1 && StringComparer.OrdinalIgnoreCase.Equals(x: "test.missing", y: ids[0])
+                ),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>()
+            );
+        packageCache.Received(1).SetVersions(Arg.Any<IReadOnlyList<PackageVersion>>());
+    }
+
+    [Fact]
     public async Task UpdateAsync_WhenRegistryFindsNoPackages_ReturnsEmpty()
     {
         await this.CreateDummyCsprojAsync();

--- a/src/Credfeto.Package/Services/PackageUpdater.cs
+++ b/src/Credfeto.Package/Services/PackageUpdater.cs
@@ -66,7 +66,7 @@ public sealed class PackageUpdater : IPackageUpdater
 
         IReadOnlyList<PackageVersion> matching;
 
-        if (cachedVersions.Count != packageIds.Count)
+        if (cachedVersions.Count == 0)
         {
             matching = await this._packageRegistry.FindPackagesAsync(
                 packageIds: packageIds,
@@ -82,6 +82,30 @@ public sealed class PackageUpdater : IPackageUpdater
             }
 
             this._packageCache.SetVersions(matching);
+        }
+        else if (cachedVersions.Count != packageIds.Count)
+        {
+            HashSet<string> cachedPackageIds = new(
+                cachedVersions.Select(cached => cached.PackageId),
+                StringComparer.OrdinalIgnoreCase
+            );
+            IReadOnlyList<string> missingPackageIds =
+            [
+                .. packageIds.Where(packageId => !cachedPackageIds.Contains(packageId)),
+            ];
+
+            IReadOnlyList<PackageVersion> fetched = await this._packageRegistry.FindPackagesAsync(
+                packageIds: missingPackageIds,
+                packageSources: packageSources,
+                cancellationToken: cancellationToken
+            );
+
+            if (fetched is not [])
+            {
+                this._packageCache.SetVersions(fetched);
+            }
+
+            matching = [.. cachedVersions, .. fetched];
         }
         else
         {
@@ -222,8 +246,6 @@ public sealed class PackageUpdater : IPackageUpdater
     {
         return this._projectLoader.LoadAsync(path: fileName, cancellationToken: cancellationToken).AsTask();
     }
-
-
 
     private static IReadOnlyList<string> FindProjects(string folder)
     {


### PR DESCRIPTION
## Summary

`PackageUpdater.UpdateAsync` currently treats the version cache as all-or-nothing: if even one requested package id is missing from the cache, every package id is re-fetched from the remote registry, discarding the benefit of the cache for a single miss.

This PR will change the cache-miss handling so only the package ids missing from the cache are queried against the registry, merging those results with the cached versions. The full-fetch path is retained only when the cache is completely empty.

See the approved implementation plan in issue comments for full detail.

Closes #572

## Test plan
- [ ] Add coverage for the partial cache-hit path in `PackageUpdaterTests.cs`
- [ ] Existing empty-cache and full-cache-hit tests continue to pass
- [ ] `dotnet build` and `dotnet test` pass