### PR TITLE
fix: report per-source NuGet failures individually instead of aborting opaquely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - CI workflow fixes: add checkout before local actions, skip SOURCE_PUSH_TOKEN-dependent jobs for Dependabot PRs
 - Prevent crash when a PackageReference or SDK version attribute contains an unparseable value such as an MSBuild property, version range, or floating version
 - Avoid re-querying the registry for every package when only some package ids are missing from the version cache
+- NuGet source failures during package updates are now reported individually, naming every failed source and reason, instead of a single opaque exception
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.Package.Tests/DependencyInjectionTests.cs
@@ -27,6 +27,12 @@ public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
         this.RequireService<IPackageRegistry>();
     }
 
+    [Fact]
+    public void PackageMetadataFetcherMustBeRegistered()
+    {
+        this.RequireService<IPackageMetadataFetcher>();
+    }
+
     private static IServiceCollection Configure(IServiceCollection services)
     {
         return services.AddPackageUpdater();

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Package.Exceptions;
+using Credfeto.Package.Services;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Credfeto.Package.Tests.Services;
+
+public sealed class PackageRegistryTests : LoggingTestBase
+{
+    private const string DeadSourceUrl = "https://dead.example/index.json";
+    private const string AliveSourceUrl = "https://alive.example/index.json";
+    private const string DeadSourceUrl2 = "https://dead-two.example/index.json";
+
+    public PackageRegistryTests(ITestOutputHelper output)
+        : base(output) { }
+
+    private PackageRegistry CreateRegistry(IPackageMetadataFetcher metadataFetcher)
+    {
+        ILogger<PackageRegistry> logger = this.GetTypedLogger<PackageRegistry>();
+
+        return new(metadataFetcher: metadataFetcher, logger: logger);
+    }
+
+    private static IEnumerable<IPackageSearchMetadata> MetadataFor(string packageId, string version)
+    {
+        IPackageSearchMetadata metadata = GetSubstitute<IPackageSearchMetadata>();
+        metadata.Identity.Returns(new PackageIdentity(id: packageId, version: NuGetVersion.Parse(version)));
+
+        return [metadata];
+    }
+
+    [Fact]
+    public async Task FindPackagesAsync_WhenOneSourceFails_ReturnsResultsFromRemainingSources()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<PackageSource>(source => StringComparer.Ordinal.Equals(source.Source, DeadSourceUrl)),
+                packageId: "Test.Package",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                Task.FromException<IEnumerable<IPackageSearchMetadata>>(new HttpRequestException("feed unreachable"))
+            );
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<PackageSource>(source => StringComparer.Ordinal.Equals(source.Source, AliveSourceUrl)),
+                packageId: "Test.Package",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.2.3")));
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
+            packageIds: ["Test.Package"],
+            packageSources: [DeadSourceUrl, AliveSourceUrl],
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: "Test.Package", actual: found.PackageId);
+        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found.Version);
+    }
+
+    [Fact]
+    public Task FindPackagesAsync_WhenAllSourcesFail_ThrowsUpdateFailedException()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        metadataFetcher
+            .GetMetadataAsync(Arg.Any<PackageSource>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromException<IEnumerable<IPackageSearchMetadata>>(new HttpRequestException("feed unreachable"))
+            );
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        return Assert.ThrowsAsync<UpdateFailedException>(() =>
+            registry
+                .FindPackagesAsync(
+                    packageIds: ["Test.Package"],
+                    packageSources: [DeadSourceUrl, DeadSourceUrl2],
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+}

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -41,7 +41,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
     }
 
     [Fact]
-    public async Task FindPackagesAsync_WhenOneSourceFails_ReturnsResultsFromRemainingSources()
+    public Task FindPackagesAsync_WhenOneSourceFails_ThrowsUpdateFailedException()
     {
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
@@ -65,15 +65,15 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 
-        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
-            packageIds: ["Test.Package"],
-            packageSources: [DeadSourceUrl, AliveSourceUrl],
-            cancellationToken: this.CancellationToken()
+        return Assert.ThrowsAsync<UpdateFailedException>(() =>
+            registry
+                .FindPackagesAsync(
+                    packageIds: ["Test.Package"],
+                    packageSources: [DeadSourceUrl, AliveSourceUrl],
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
         );
-
-        PackageVersion found = Assert.Single(result);
-        Assert.Equal(expected: "Test.Package", actual: found.PackageId);
-        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found.Version);
     }
 
     [Fact]
@@ -98,5 +98,27 @@ public sealed class PackageRegistryTests : LoggingTestBase
                 )
                 .AsTask()
         );
+    }
+
+    [Fact]
+    public async Task FindPackagesAsync_WhenAllSourcesSucceed_ReturnsResults()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        metadataFetcher
+            .GetMetadataAsync(Arg.Any<PackageSource>(), packageId: "Test.Package", Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.2.3")));
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
+            packageIds: ["Test.Package"],
+            packageSources: [AliveSourceUrl],
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: "Test.Package", actual: found.PackageId);
+        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found.Version);
     }
 }

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -40,8 +40,17 @@ public sealed class PackageRegistryTests : LoggingTestBase
         return [metadata];
     }
 
+    private static (string FailedPart, string SucceededPart) SplitOnSucceeded(string message)
+    {
+        const string marker = "Succeeded: ";
+        int index = message.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(index >= 0, $"Expected message to contain '{marker}': {message}");
+
+        return (message[..index], message[index..]);
+    }
+
     [Fact]
-    public Task FindPackagesAsync_WhenOneSourceFails_ThrowsUpdateFailedException()
+    public async Task FindPackagesAsync_WhenOneSourceFails_ThrowsUpdateFailedException()
     {
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
@@ -65,7 +74,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 
-        return Assert.ThrowsAsync<UpdateFailedException>(() =>
+        UpdateFailedException exception = await Assert.ThrowsAsync<UpdateFailedException>(() =>
             registry
                 .FindPackagesAsync(
                     packageIds: ["Test.Package"],
@@ -74,10 +83,33 @@ public sealed class PackageRegistryTests : LoggingTestBase
                 )
                 .AsTask()
         );
+
+        (string failedPart, string succeededPart) = SplitOnSucceeded(exception.Message);
+
+        Assert.Contains(
+            expectedSubstring: "Custom0",
+            actualString: failedPart,
+            comparisonType: StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            expectedSubstring: "Custom1",
+            actualString: failedPart,
+            comparisonType: StringComparison.Ordinal
+        );
+        Assert.Contains(
+            expectedSubstring: "Custom1",
+            actualString: succeededPart,
+            comparisonType: StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            expectedSubstring: "Custom0",
+            actualString: succeededPart,
+            comparisonType: StringComparison.Ordinal
+        );
     }
 
     [Fact]
-    public Task FindPackagesAsync_WhenAllSourcesFail_ThrowsUpdateFailedException()
+    public async Task FindPackagesAsync_WhenAllSourcesFail_ThrowsUpdateFailedException()
     {
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
@@ -89,7 +121,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 
-        return Assert.ThrowsAsync<UpdateFailedException>(() =>
+        UpdateFailedException exception = await Assert.ThrowsAsync<UpdateFailedException>(() =>
             registry
                 .FindPackagesAsync(
                     packageIds: ["Test.Package"],
@@ -97,6 +129,22 @@ public sealed class PackageRegistryTests : LoggingTestBase
                     cancellationToken: this.CancellationToken()
                 )
                 .AsTask()
+        );
+
+        Assert.Contains(
+            expectedSubstring: "Custom0",
+            actualString: exception.Message,
+            comparisonType: StringComparison.Ordinal
+        );
+        Assert.Contains(
+            expectedSubstring: "Custom1",
+            actualString: exception.Message,
+            comparisonType: StringComparison.Ordinal
+        );
+        Assert.Contains(
+            expectedSubstring: "Succeeded: (none)",
+            actualString: exception.Message,
+            comparisonType: StringComparison.Ordinal
         );
     }
 

--- a/src/Credfeto.Package/IPackageMetadataFetcher.cs
+++ b/src/Credfeto.Package/IPackageMetadataFetcher.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+
+namespace Credfeto.Package;
+
+public interface IPackageMetadataFetcher
+{
+    Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
+        PackageSource packageSource,
+        string packageId,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Credfeto.Package/PackageUpdaterSetup.cs
+++ b/src/Credfeto.Package/PackageUpdaterSetup.cs
@@ -11,6 +11,7 @@ public static class PackageUpdaterSetup
             .AddSingleton<IPackageCache, PackageCache>()
             .AddSingleton<IProjectLoader, ProjectLoader>()
             .AddSingleton<IPackageUpdater, PackageUpdater>()
+            .AddSingleton<IPackageMetadataFetcher, PackageMetadataFetcher>()
             .AddSingleton<IPackageRegistry, PackageRegistry>();
     }
 }

--- a/src/Credfeto.Package/Services/LoggingExtensions/PackageRegistryLoggingExtensions.cs
+++ b/src/Credfeto.Package/Services/LoggingExtensions/PackageRegistryLoggingExtensions.cs
@@ -41,11 +41,14 @@ internal static partial class PackageRegistryLoggingExtensions
     [LoggerMessage(
         EventId = 3,
         Level = LogLevel.Error,
-        Message = "All {sourceCount} package sources failed while looking up {packageId}"
+        Message = "{failedCount} of {sourceCount} package sources failed while looking up {packageId}. Failed: {failedSources}. Succeeded: {succeededSources}"
     )]
-    public static partial void AllPackageSourcesFailed(
+    public static partial void PackageSourcesFailed(
         this ILogger<PackageRegistry> logger,
+        int failedCount,
         int sourceCount,
-        string packageId
+        string packageId,
+        string failedSources,
+        string succeededSources
     );
 }

--- a/src/Credfeto.Package/Services/LoggingExtensions/PackageRegistryLoggingExtensions.cs
+++ b/src/Credfeto.Package/Services/LoggingExtensions/PackageRegistryLoggingExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 
@@ -23,4 +24,28 @@ internal static partial class PackageRegistryLoggingExtensions
         Message = "Enumerating matching package versions for {packageId}..."
     )]
     public static partial void EnumeratingPackageVersions(this ILogger<PackageRegistry> logger, string packageId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "Package source {source} failed while looking up {packageId}: {message}"
+    )]
+    public static partial void PackageSourceQueryFailed(
+        this ILogger<PackageRegistry> logger,
+        string source,
+        string packageId,
+        string message,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "All {sourceCount} package sources failed while looking up {packageId}"
+    )]
+    public static partial void AllPackageSourcesFailed(
+        this ILogger<PackageRegistry> logger,
+        int sourceCount,
+        string packageId
+    );
 }

--- a/src/Credfeto.Package/Services/PackageMetadataFetcher.cs
+++ b/src/Credfeto.Package/Services/PackageMetadataFetcher.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+
+namespace Credfeto.Package.Services;
+
+public sealed class PackageMetadataFetcher : IPackageMetadataFetcher
+{
+    private const bool INCLUDE_UNLISTED_PACKAGES = false;
+
+    public async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
+        PackageSource packageSource,
+        string packageId,
+        CancellationToken cancellationToken
+    )
+    {
+        SourceRepository sourceRepository = new(source: packageSource, [.. Repository.Provider.GetCoreV3()]);
+
+        PackageMetadataResource metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(
+            cancellationToken
+        );
+
+        using SourceCacheContext sourceCacheContext = new();
+
+        return await metadataResource.GetMetadataAsync(
+            packageId: packageId,
+            includePrerelease: false,
+            includeUnlisted: INCLUDE_UNLISTED_PACKAGES,
+            sourceCacheContext: sourceCacheContext,
+            log: NullLogger.Instance,
+            token: cancellationToken
+        );
+    }
+}

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -151,14 +151,30 @@ public sealed class PackageRegistry : IPackageRegistry
             )
         );
 
-        int failureCount = failures.Count(failure => failure is not null);
-
-        if (sources.Count != 0 && failureCount == sources.Count)
+        if (failures.Any(failure => failure is not null))
         {
-            this._logger.AllPackageSourcesFailed(sourceCount: sources.Count, packageId: packageId);
+            IReadOnlyList<(PackageSource Source, Exception? Failure)> outcomes = [.. sources.Zip(failures)];
+            IReadOnlyList<string> failedSources =
+            [
+                .. outcomes.Where(o => o.Failure is not null).Select(o => o.Source.Name),
+            ];
+            IReadOnlyList<string> succeededSources =
+            [
+                .. outcomes.Where(o => o.Failure is null).Select(o => o.Source.Name),
+            ];
+
+            this._logger.PackageSourcesFailed(
+                failedCount: failedSources.Count,
+                sourceCount: sources.Count,
+                packageId: packageId,
+                failedSources: string.Join(separator: ", ", failedSources),
+                succeededSources: succeededSources.Count == 0
+                    ? "(none)"
+                    : string.Join(separator: ", ", succeededSources)
+            );
 
             throw new UpdateFailedException(
-                $"All {sources.Count} package sources failed while looking up {packageId}",
+                $"{failedSources.Count} of {sources.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}",
                 new AggregateException(failures.OfType<Exception>())
             );
         }

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.Package.Exceptions;
 using Credfeto.Package.Services.LoggingExtensions;
 using Microsoft.Extensions.Logging;
 using NonBlocking;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -15,12 +15,12 @@ namespace Credfeto.Package.Services;
 
 public sealed class PackageRegistry : IPackageRegistry
 {
-    private const bool INCLUDE_UNLISTED_PACKAGES = false;
-
+    private readonly IPackageMetadataFetcher _metadataFetcher;
     private readonly ILogger<PackageRegistry> _logger;
 
-    public PackageRegistry(ILogger<PackageRegistry> logger)
+    public PackageRegistry(IPackageMetadataFetcher metadataFetcher, ILogger<PackageRegistry> logger)
     {
+        this._metadataFetcher = metadataFetcher;
         this._logger = logger;
     }
 
@@ -66,21 +66,10 @@ public sealed class PackageRegistry : IPackageRegistry
         CancellationToken cancellationToken
     )
     {
-        SourceRepository sourceRepository = new(source: packageSource, [.. Repository.Provider.GetCoreV3()]);
-
-        PackageMetadataResource metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(
-            cancellationToken
-        );
-
-        using SourceCacheContext sourceCacheContext = new();
-
-        IEnumerable<IPackageSearchMetadata> result = await metadataResource.GetMetadataAsync(
+        IEnumerable<IPackageSearchMetadata> result = await this._metadataFetcher.GetMetadataAsync(
+            packageSource: packageSource,
             packageId: packageId,
-            includePrerelease: false,
-            includeUnlisted: INCLUDE_UNLISTED_PACKAGES,
-            sourceCacheContext: sourceCacheContext,
-            log: NullLogger.Instance,
-            token: cancellationToken
+            cancellationToken: cancellationToken
         );
 
         foreach (
@@ -151,9 +140,9 @@ public sealed class PackageRegistry : IPackageRegistry
 
         ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
 
-        await Task.WhenAll(
+        Exception?[] failures = await Task.WhenAll(
             sources.Select(selector: source =>
-                this.LoadPackagesFromSourceAsync(
+                this.LoadPackagesFromSourceSafeAsync(
                     packageSource: source,
                     packageId: packageId,
                     found: found,
@@ -162,9 +151,56 @@ public sealed class PackageRegistry : IPackageRegistry
             )
         );
 
+        int failureCount = failures.Count(failure => failure is not null);
+
+        if (sources.Count != 0 && failureCount == sources.Count)
+        {
+            this._logger.AllPackageSourcesFailed(sourceCount: sources.Count, packageId: packageId);
+
+            throw new UpdateFailedException(
+                $"All {sources.Count} package sources failed while looking up {packageId}",
+                new AggregateException(failures.OfType<Exception>())
+            );
+        }
+
         foreach ((string key, NuGetVersion value) in found)
         {
             packages.TryAdd(key: key, value: value);
+        }
+    }
+
+    private async Task<Exception?> LoadPackagesFromSourceSafeAsync(
+        PackageSource packageSource,
+        string packageId,
+        ConcurrentDictionary<string, NuGetVersion> found,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await this.LoadPackagesFromSourceAsync(
+                packageSource: packageSource,
+                packageId: packageId,
+                found: found,
+                cancellationToken: cancellationToken
+            );
+
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this._logger.PackageSourceQueryFailed(
+                source: packageSource.Name,
+                packageId: packageId,
+                message: exception.Message,
+                exception: exception
+            );
+
+            return exception;
         }
     }
 }

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -162,19 +162,19 @@ public sealed class PackageRegistry : IPackageRegistry
             [
                 .. outcomes.Where(o => o.Failure is null).Select(o => o.Source.Name),
             ];
+            string succeededSourcesMessage =
+                succeededSources.Count == 0 ? "(none)" : string.Join(separator: ", ", succeededSources);
 
             this._logger.PackageSourcesFailed(
                 failedCount: failedSources.Count,
                 sourceCount: sources.Count,
                 packageId: packageId,
                 failedSources: string.Join(separator: ", ", failedSources),
-                succeededSources: succeededSources.Count == 0
-                    ? "(none)"
-                    : string.Join(separator: ", ", succeededSources)
+                succeededSources: succeededSourcesMessage
             );
 
             throw new UpdateFailedException(
-                $"{failedSources.Count} of {sources.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}",
+                $"{failedSources.Count} of {sources.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}. Succeeded: {succeededSourcesMessage}",
                 new AggregateException(failures.OfType<Exception>())
             );
         }


### PR DESCRIPTION
## Summary

`PackageRegistry.FindPackageInSourcesAsync` fans out to all configured NuGet sources with `Task.WhenAll`, and `LoadPackagesFromSourceAsync` has no exception handling — a single source failure (DNS, HTTP 5xx, auth, timeout) propagates as an opaque exception and aborts the whole lookup, with no indication of which source(s) failed or why.

Per discussion on the issue, the fix keeps the existing fail-on-any-source-error behaviour (a partial source failure is not safe to silently ignore — see the release/pre-release feed example) but makes the failure diagnosable: every source is driven to completion, each failure is logged individually, and if any source failed the resulting exception names every failed source and reason alongside the sources that succeeded.

This PR currently contains only the placeholder CHANGELOG entry; the implementation follows in subsequent commits per the approved plan on the issue.

## Implementation Plan

See the approved plan on the issue for full details:
- `src/Credfeto.Package/Services/PackageRegistry.cs` — add a `LoadPackagesFromSourceSafeAsync` wrapper that catches per-source exceptions (re-throwing `OperationCanceledException` immediately), collects failures, and throws a descriptive exception naming every failed/succeeded source if any source failed.
- `src/Credfeto.Package/Services/LoggingExtensions/PackageRegistryLoggingExtensions.cs` — add `FailedToLoadPackagesFromSource` and summary `[LoggerMessage]` Error entries.
- `src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs` (new) — partial-failure, all-sources-failure, and all-succeed test coverage.

Closes #567

## Test plan

- [ ] Unit tests for partial source failure (mixed valid/invalid sources)
- [ ] Unit tests for all-sources failure
- [ ] Unit tests for all-sources success (no regression)
- [ ] `dotnet build` and full test suite pass