### PR TITLE
perf: avoid re-parsing and re-sorting Project.Packages on every package update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention
 - SDK - Updated DotNet SDK to 10.0.301
 - Use PackageMetadataResource.GetMetadataAsync for exact package id lookup instead of SearchAsync with take: int.MaxValue
+- Avoid re-parsing and re-sorting all package versions on every package update; check package presence directly against the raw XML elements instead
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Package.Tests/Services/ProjectTests.cs
+++ b/src/Credfeto.Package.Tests/Services/ProjectTests.cs
@@ -129,4 +129,107 @@ public sealed class ProjectTests : LoggingFolderCleanupTestBase
         Assert.Equal(expected: "Some.Sdk", actual: entry.PackageId);
         Assert.Equal(expected: new NuGetVersion("1.2.3"), actual: entry.Version);
     }
+
+    [Fact]
+    public async Task UpdatePackage_WhenPackagePresentWithHigherVersion_ReturnsTrueAndUpdatesReference()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        bool updated = project.UpdatePackage(new(packageId: "Some.Package", new NuGetVersion("2.0.0")));
+
+        Assert.True(updated, userMessage: "Expected update to report a change");
+        Assert.True(project.Changed, userMessage: "Expected project to be marked as changed");
+        PackageVersion entry = Assert.Single(project.Packages);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: entry.Version);
+    }
+
+    [Fact]
+    public async Task UpdatePackage_WhenPackagePresentWithLowerOrEqualVersion_ReturnsFalse()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="2.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        bool updated = project.UpdatePackage(new(packageId: "Some.Package", new NuGetVersion("1.0.0")));
+
+        Assert.False(updated, userMessage: "Expected no update to be reported for a non-upgrading version");
+        Assert.False(project.Changed, userMessage: "Expected project to remain unchanged");
+        PackageVersion entry = Assert.Single(project.Packages);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: entry.Version);
+    }
+
+    [Fact]
+    public async Task UpdatePackage_WhenPackageNotPresent_ReturnsFalse()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Other.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        bool updated = project.UpdatePackage(new(packageId: "Some.Package", new NuGetVersion("2.0.0")));
+
+        Assert.False(updated, userMessage: "Expected no update when the package is not referenced at all");
+        Assert.False(project.Changed, userMessage: "Expected project to remain unchanged");
+    }
+
+    [Fact]
+    public async Task UpdatePackage_WhenPackagePresentOnlyWithUnparseableVersion_ReturnsFalse()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        bool updated = project.UpdatePackage(new(packageId: "Some.Package", new NuGetVersion("2.0.0")));
+
+        Assert.False(updated, userMessage: "Expected no update when the only reference has an unparseable version");
+        Assert.False(project.Changed, userMessage: "Expected project to remain unchanged");
+    }
+
+    [Fact]
+    public async Task UpdatePackage_WhenPackagePresentOnlyViaSdkAttribute_ReturnsTrueAndUpdatesSdk()
+    {
+        IProject? project = await this.LoadProjectAsync(
+            """
+            <Project Sdk="Some.Sdk/1.2.3">
+            </Project>
+            """
+        );
+
+        Assert.NotNull(project);
+        bool updated = project.UpdatePackage(new(packageId: "Some.Sdk", new NuGetVersion("1.3.0")));
+
+        Assert.True(updated, userMessage: "Expected update to report a change");
+        Assert.True(project.Changed, userMessage: "Expected project to be marked as changed");
+        PackageVersion entry = Assert.Single(project.Packages);
+        Assert.Equal(expected: new NuGetVersion("1.3.0"), actual: entry.Version);
+    }
 }

--- a/src/Credfeto.Package/Services/Project.cs
+++ b/src/Credfeto.Package/Services/Project.cs
@@ -40,7 +40,7 @@ internal sealed class Project : IProject
 
     public bool UpdatePackage(PackageVersion package)
     {
-        if (this.Packages.All(p => !StringComparer.OrdinalIgnoreCase.Equals(x: p.PackageId, y: package.PackageId)))
+        if (!this.HasPackageReference(package.PackageId))
         {
             return false;
         }
@@ -139,6 +139,26 @@ internal sealed class Project : IProject
         }
 
         return true;
+    }
+
+    private bool HasPackageReference(string packageId)
+    {
+        bool hasReference = this.GetPackageReferences()
+            .Any(node => StringComparer.OrdinalIgnoreCase.Equals(x: node.GetAttribute("Include"), y: packageId));
+
+        return hasReference || this.HasSdkReference(packageId);
+    }
+
+    private bool HasSdkReference(string packageId)
+    {
+        if (this._doc.SelectSingleNode("/Project") is not XmlElement project)
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> sdk = project.GetAttribute("Sdk").Split("/");
+
+        return sdk.Count == 2 && StringComparer.OrdinalIgnoreCase.Equals(x: sdk[0], y: packageId);
     }
 
     private IReadOnlyList<PackageVersion> GetCurrentPackageVersions()


### PR DESCRIPTION
## Summary

`Project.UpdatePackage` currently answers "does this project reference package X?" by materialising the full `Packages` list (parsing every version and sorting), just to run a containment check. This is scaffolding for the fix described in the approved implementation plan on #575.

Implementation, tests, and changelog details will follow in subsequent commits on this PR per the approved plan.

Closes #575