### PR TITLE
perf: reuse SourceRepository per source instead of rebuilding it per package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - SDK - Updated DotNet SDK to 10.0.301
 - Use PackageMetadataResource.GetMetadataAsync for exact package id lookup instead of SearchAsync with take: int.MaxValue
 - Avoid re-parsing and re-sorting all package versions on every package update; check package presence directly against the raw XML elements instead
+- Reuse each NuGet source's SourceRepository across package lookups instead of rebuilding it per package, restoring NuGet's resource and HTTP caching.
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -8,7 +8,6 @@ using Credfeto.Package.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -56,7 +55,9 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         metadataFetcher
             .GetMetadataAsync(
-                Arg.Is<PackageSource>(source => StringComparer.Ordinal.Equals(source.Source, DeadSourceUrl)),
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl)
+                ),
                 packageId: "Test.Package",
                 Arg.Any<CancellationToken>()
             )
@@ -66,7 +67,9 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         metadataFetcher
             .GetMetadataAsync(
-                Arg.Is<PackageSource>(source => StringComparer.Ordinal.Equals(source.Source, AliveSourceUrl)),
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
+                ),
                 packageId: "Test.Package",
                 Arg.Any<CancellationToken>()
             )
@@ -114,7 +117,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
         metadataFetcher
-            .GetMetadataAsync(Arg.Any<PackageSource>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetMetadataAsync(Arg.Any<SourceRepository>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(
                 Task.FromException<IEnumerable<IPackageSearchMetadata>>(new HttpRequestException("feed unreachable"))
             );
@@ -154,7 +157,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
         metadataFetcher
-            .GetMetadataAsync(Arg.Any<PackageSource>(), packageId: "Test.Package", Arg.Any<CancellationToken>())
+            .GetMetadataAsync(Arg.Any<SourceRepository>(), packageId: "Test.Package", Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.2.3")));
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);

--- a/src/Credfeto.Package/IPackageMetadataFetcher.cs
+++ b/src/Credfeto.Package/IPackageMetadataFetcher.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
 namespace Credfeto.Package;
@@ -9,7 +8,7 @@ namespace Credfeto.Package;
 public interface IPackageMetadataFetcher
 {
     Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
-        PackageSource packageSource,
+        SourceRepository sourceRepository,
         string packageId,
         CancellationToken cancellationToken
     );

--- a/src/Credfeto.Package/Services/PackageMetadataFetcher.cs
+++ b/src/Credfeto.Package/Services/PackageMetadataFetcher.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
 namespace Credfeto.Package.Services;
@@ -12,13 +11,11 @@ public sealed class PackageMetadataFetcher : IPackageMetadataFetcher
     private const bool INCLUDE_UNLISTED_PACKAGES = false;
 
     public async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
-        PackageSource packageSource,
+        SourceRepository sourceRepository,
         string packageId,
         CancellationToken cancellationToken
     )
     {
-        SourceRepository sourceRepository = new(source: packageSource, [.. Repository.Provider.GetCoreV3()]);
-
         PackageMetadataResource metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(
             cancellationToken
         );

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -30,14 +30,14 @@ public sealed class PackageRegistry : IPackageRegistry
         CancellationToken cancellationToken
     )
     {
-        IReadOnlyList<PackageSource> sources = DefinePackageSources(packageSources);
+        IReadOnlyList<SourceRepository> sourceRepositories = DefineSourceRepositories(packageSources);
 
         ConcurrentDictionary<string, NuGetVersion> packages = new(StringComparer.OrdinalIgnoreCase);
 
         foreach (string packageId in packageIds)
         {
             await this.FindPackageInSourcesAsync(
-                sources: sources,
+                sourceRepositories: sourceRepositories,
                 packageId: packageId,
                 packages: packages,
                 cancellationToken: cancellationToken
@@ -47,11 +47,18 @@ public sealed class PackageRegistry : IPackageRegistry
         return [.. packages.Select(p => new PackageVersion(packageId: p.Key, version: p.Value))];
     }
 
-    private static IReadOnlyList<PackageSource> DefinePackageSources(IReadOnlyList<string> sources)
+    private static IReadOnlyList<SourceRepository> DefineSourceRepositories(IReadOnlyList<string> sources)
     {
         PackageSourceProvider packageSourceProvider = new(Settings.LoadDefaultSettings(Environment.CurrentDirectory));
 
-        return [.. packageSourceProvider.LoadPackageSources().Concat(sources.Select(CreateCustomPackageSource))];
+        IReadOnlyList<PackageSource> packageSources =
+        [
+            .. packageSourceProvider.LoadPackageSources().Concat(sources.Select(CreateCustomPackageSource)),
+        ];
+
+        IReadOnlyList<Lazy<INuGetResourceProvider>> providers = [.. Repository.Provider.GetCoreV3()];
+
+        return [.. packageSources.Select(packageSource => new SourceRepository(source: packageSource, providers))];
     }
 
     private static PackageSource CreateCustomPackageSource(string source, int sourceId)
@@ -60,14 +67,14 @@ public sealed class PackageRegistry : IPackageRegistry
     }
 
     private async Task LoadPackagesFromSourceAsync(
-        PackageSource packageSource,
+        SourceRepository sourceRepository,
         string packageId,
         ConcurrentDictionary<string, NuGetVersion> found,
         CancellationToken cancellationToken
     )
     {
         IEnumerable<IPackageSearchMetadata> result = await this._metadataFetcher.GetMetadataAsync(
-            packageSource: packageSource,
+            sourceRepository: sourceRepository,
             packageId: packageId,
             cancellationToken: cancellationToken
         );
@@ -82,7 +89,7 @@ public sealed class PackageRegistry : IPackageRegistry
             if (found.TryGetValue(key: packageVersion.PackageId, out NuGetVersion? existingVersion))
             {
                 this.DoUpdateRegisteredFoundPackage(
-                    packageSource: packageSource,
+                    packageSource: sourceRepository.PackageSource,
                     found: found,
                     existingVersion: existingVersion,
                     packageVersion: packageVersion
@@ -93,7 +100,7 @@ public sealed class PackageRegistry : IPackageRegistry
                 this._logger.FoundPackageInSource(
                     packageId: packageVersion.PackageId,
                     version: packageVersion.Version,
-                    source: packageSource.Source
+                    source: sourceRepository.PackageSource.Source
                 );
             }
         }
@@ -130,7 +137,7 @@ public sealed class PackageRegistry : IPackageRegistry
     }
 
     private async ValueTask FindPackageInSourcesAsync(
-        IReadOnlyList<PackageSource> sources,
+        IReadOnlyList<SourceRepository> sourceRepositories,
         string packageId,
         ConcurrentDictionary<string, NuGetVersion> packages,
         CancellationToken cancellationToken
@@ -141,9 +148,9 @@ public sealed class PackageRegistry : IPackageRegistry
         ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
 
         Exception?[] failures = await Task.WhenAll(
-            sources.Select(selector: source =>
+            sourceRepositories.Select(selector: sourceRepository =>
                 this.LoadPackagesFromSourceSafeAsync(
-                    packageSource: source,
+                    sourceRepository: sourceRepository,
                     packageId: packageId,
                     found: found,
                     cancellationToken: cancellationToken
@@ -153,28 +160,31 @@ public sealed class PackageRegistry : IPackageRegistry
 
         if (failures.Any(failure => failure is not null))
         {
-            IReadOnlyList<(PackageSource Source, Exception? Failure)> outcomes = [.. sources.Zip(failures)];
+            IReadOnlyList<(SourceRepository SourceRepository, Exception? Failure)> outcomes =
+            [
+                .. sourceRepositories.Zip(failures),
+            ];
             IReadOnlyList<string> failedSources =
             [
-                .. outcomes.Where(o => o.Failure is not null).Select(o => o.Source.Name),
+                .. outcomes.Where(o => o.Failure is not null).Select(o => o.SourceRepository.PackageSource.Name),
             ];
             IReadOnlyList<string> succeededSources =
             [
-                .. outcomes.Where(o => o.Failure is null).Select(o => o.Source.Name),
+                .. outcomes.Where(o => o.Failure is null).Select(o => o.SourceRepository.PackageSource.Name),
             ];
             string succeededSourcesMessage =
                 succeededSources.Count == 0 ? "(none)" : string.Join(separator: ", ", succeededSources);
 
             this._logger.PackageSourcesFailed(
                 failedCount: failedSources.Count,
-                sourceCount: sources.Count,
+                sourceCount: sourceRepositories.Count,
                 packageId: packageId,
                 failedSources: string.Join(separator: ", ", failedSources),
                 succeededSources: succeededSourcesMessage
             );
 
             throw new UpdateFailedException(
-                $"{failedSources.Count} of {sources.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}. Succeeded: {succeededSourcesMessage}",
+                $"{failedSources.Count} of {sourceRepositories.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}. Succeeded: {succeededSourcesMessage}",
                 new AggregateException(failures.OfType<Exception>())
             );
         }
@@ -186,7 +196,7 @@ public sealed class PackageRegistry : IPackageRegistry
     }
 
     private async Task<Exception?> LoadPackagesFromSourceSafeAsync(
-        PackageSource packageSource,
+        SourceRepository sourceRepository,
         string packageId,
         ConcurrentDictionary<string, NuGetVersion> found,
         CancellationToken cancellationToken
@@ -195,7 +205,7 @@ public sealed class PackageRegistry : IPackageRegistry
         try
         {
             await this.LoadPackagesFromSourceAsync(
-                packageSource: packageSource,
+                sourceRepository: sourceRepository,
                 packageId: packageId,
                 found: found,
                 cancellationToken: cancellationToken
@@ -210,7 +220,7 @@ public sealed class PackageRegistry : IPackageRegistry
         catch (Exception exception)
         {
             this._logger.PackageSourceQueryFailed(
-                source: packageSource.Name,
+                source: sourceRepository.PackageSource.Name,
                 packageId: packageId,
                 message: exception.Message,
                 exception: exception


### PR DESCRIPTION
## Summary
- `PackageRegistry.FindPackagesAsync` now builds one `SourceRepository` per `PackageSource` up front instead of a fresh `SourceRepository` for every `(package id x package source)` pair.
- `SourceRepository` is threaded through `FindPackageInSourcesAsync` / `LoadPackagesFromSourceAsync` and `IPackageMetadataFetcher.GetMetadataAsync` (replacing `PackageSource` in those signatures), restoring NuGet's per-repository caching of resources, service-index lookups, and HTTP handlers.
- No observable behaviour change: same filtering, banned-package logic, and cross-source "pick latest version" precedence.

## Test plan
- [x] `dotnet build` (Release) — 0 warnings, 0 errors
- [x] Full pre-commit baseline (`pre-commit --all-files`, incl. build + `buildcheck` + tests) — all checks passed
- [x] `Credfeto.Package.Tests` (92 tests) — all passed, including updated `PackageRegistryTests` covering source-fetch failure/success paths

Closes #573