### PR TITLE
fix: never drop the highest package version in a concurrent feed race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Prevent crash when a PackageReference or SDK version attribute contains an unparseable value such as an MSBuild property, version range, or floating version
 - Avoid re-querying the registry for every package when only some package ids are missing from the version cache
 - NuGet source failures during package updates are now reported individually, naming every failed source and reason, instead of a single opaque exception
+- Concurrent package version lookups across NuGet feeds no longer silently drop the highest version when two feeds race to update the same package
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -7,7 +7,6 @@ using Credfeto.Package.Exceptions;
 using Credfeto.Package.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.Logging;
-using NonBlocking;
 using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
@@ -182,9 +181,47 @@ public sealed class PackageRegistryTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task FindPackagesAsync_WhenMultipleSourcesReturnDifferentVersions_ReturnsTheHighestVersion()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
+                ),
+                packageId: "Test.Package",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.5.0")));
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl2)
+                ),
+                packageId: "Test.Package",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "2.0.0")));
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
+            packageIds: ["Test.Package"],
+            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: "Test.Package", actual: found.PackageId);
+        Assert.Equal(expected: NuGetVersion.Parse("2.0.0"), actual: found.Version);
+    }
+
+    [Fact]
     public void RegisterFoundPackageVersion_WhenKeyNotPresent_AddsCandidate()
     {
-        ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
         PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
 
         registry.RegisterFoundPackageVersion(
@@ -207,8 +244,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
         string expected
     )
     {
-        ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
-        found[TestPackageId] = NuGetVersion.Parse(existing);
+        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal) { [TestPackageId] = NuGetVersion.Parse(existing) };
         PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
 
         registry.RegisterFoundPackageVersion(
@@ -219,89 +255,5 @@ public sealed class PackageRegistryTests : LoggingTestBase
         );
 
         Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TestPackageId]);
-    }
-
-    [Fact]
-    public async Task RegisterFoundPackageVersion_WhenCalledConcurrently_NeverDropsTheHighestVersion()
-    {
-        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
-        PackageSource source = CreateTestPackageSource();
-        NuGetVersion lowestVersion = NuGetVersion.Parse("1.0.0");
-        NuGetVersion middleVersion = NuGetVersion.Parse("1.5.0");
-        NuGetVersion highestVersion = NuGetVersion.Parse("2.0.0");
-
-        CancellationToken cancellationToken = this.CancellationToken();
-
-        for (int iteration = 0; iteration < 200; ++iteration)
-        {
-            ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
-            found[TestPackageId] = lowestVersion;
-
-            await Task.WhenAll(
-                Task.Run(
-                    () =>
-                        registry.RegisterFoundPackageVersion(
-                            packageSource: source,
-                            found: found,
-                            packageId: TestPackageId,
-                            candidateVersion: highestVersion
-                        ),
-                    cancellationToken
-                ),
-                Task.Run(
-                    () =>
-                        registry.RegisterFoundPackageVersion(
-                            packageSource: source,
-                            found: found,
-                            packageId: TestPackageId,
-                            candidateVersion: middleVersion
-                        ),
-                    cancellationToken
-                )
-            );
-
-            Assert.Equal(expected: highestVersion, actual: found[TestPackageId]);
-        }
-    }
-
-    [Fact]
-    public async Task RegisterFoundPackageVersion_WhenCalledConcurrentlyForAnAbsentKey_NeverDropsTheHighestVersion()
-    {
-        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
-        PackageSource source = CreateTestPackageSource();
-        NuGetVersion middleVersion = NuGetVersion.Parse("1.5.0");
-        NuGetVersion highestVersion = NuGetVersion.Parse("2.0.0");
-
-        CancellationToken cancellationToken = this.CancellationToken();
-
-        for (int iteration = 0; iteration < 200; ++iteration)
-        {
-            ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
-
-            await Task.WhenAll(
-                Task.Run(
-                    () =>
-                        registry.RegisterFoundPackageVersion(
-                            packageSource: source,
-                            found: found,
-                            packageId: TestPackageId,
-                            candidateVersion: highestVersion
-                        ),
-                    cancellationToken
-                ),
-                Task.Run(
-                    () =>
-                        registry.RegisterFoundPackageVersion(
-                            packageSource: source,
-                            found: found,
-                            packageId: TestPackageId,
-                            candidateVersion: middleVersion
-                        ),
-                    cancellationToken
-                )
-            );
-
-            Assert.Equal(expected: highestVersion, actual: found[TestPackageId]);
-        }
     }
 }

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -7,7 +7,9 @@ using Credfeto.Package.Exceptions;
 using Credfeto.Package.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.Logging;
+using NonBlocking;
 using NSubstitute;
+using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -20,6 +22,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
     private const string DeadSourceUrl = "https://dead.example/index.json";
     private const string AliveSourceUrl = "https://alive.example/index.json";
     private const string DeadSourceUrl2 = "https://dead-two.example/index.json";
+    private const string TestPackageId = "Test.Package";
 
     public PackageRegistryTests(ITestOutputHelper output)
         : base(output) { }
@@ -29,6 +32,11 @@ public sealed class PackageRegistryTests : LoggingTestBase
         ILogger<PackageRegistry> logger = this.GetTypedLogger<PackageRegistry>();
 
         return new(metadataFetcher: metadataFetcher, logger: logger);
+    }
+
+    private static PackageSource CreateTestPackageSource()
+    {
+        return new(source: AliveSourceUrl, name: "Alive", isEnabled: true, isOfficial: true, isPersistable: true);
     }
 
     private static IEnumerable<IPackageSearchMetadata> MetadataFor(string packageId, string version)
@@ -171,5 +179,88 @@ public sealed class PackageRegistryTests : LoggingTestBase
         PackageVersion found = Assert.Single(result);
         Assert.Equal(expected: "Test.Package", actual: found.PackageId);
         Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found.Version);
+    }
+
+    [Fact]
+    public void RegisterFoundPackageVersion_WhenKeyNotPresent_AddsCandidate()
+    {
+        ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
+
+        registry.RegisterFoundPackageVersion(
+            packageSource: CreateTestPackageSource(),
+            found: found,
+            packageId: TestPackageId,
+            candidateVersion: NuGetVersion.Parse("1.2.3")
+        );
+
+        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found[TestPackageId]);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "2.0.0", "2.0.0")] // higher candidate replaces the stored version
+    [InlineData("2.0.0", "1.0.0", "2.0.0")] // lower candidate is discarded
+    [InlineData("1.0.0", "1.0.0", "1.0.0")] // equal candidate is a no-op
+    public void RegisterFoundPackageVersion_WhenKeyAlreadyPresent_KeepsTheHigherVersion(
+        string existing,
+        string candidate,
+        string expected
+    )
+    {
+        ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+        found[TestPackageId] = NuGetVersion.Parse(existing);
+        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
+
+        registry.RegisterFoundPackageVersion(
+            packageSource: CreateTestPackageSource(),
+            found: found,
+            packageId: TestPackageId,
+            candidateVersion: NuGetVersion.Parse(candidate)
+        );
+
+        Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TestPackageId]);
+    }
+
+    [Fact]
+    public async Task RegisterFoundPackageVersion_WhenCalledConcurrently_NeverDropsTheHighestVersion()
+    {
+        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
+        PackageSource source = CreateTestPackageSource();
+        NuGetVersion lowestVersion = NuGetVersion.Parse("1.0.0");
+        NuGetVersion middleVersion = NuGetVersion.Parse("1.5.0");
+        NuGetVersion highestVersion = NuGetVersion.Parse("2.0.0");
+
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        for (int iteration = 0; iteration < 200; ++iteration)
+        {
+            ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+            found[TestPackageId] = lowestVersion;
+
+            await Task.WhenAll(
+                Task.Run(
+                    () =>
+                        registry.RegisterFoundPackageVersion(
+                            packageSource: source,
+                            found: found,
+                            packageId: TestPackageId,
+                            candidateVersion: highestVersion
+                        ),
+                    cancellationToken
+                ),
+                Task.Run(
+                    () =>
+                        registry.RegisterFoundPackageVersion(
+                            packageSource: source,
+                            found: found,
+                            packageId: TestPackageId,
+                            candidateVersion: middleVersion
+                        ),
+                    cancellationToken
+                )
+            );
+
+            Assert.Equal(expected: highestVersion, actual: found[TestPackageId]);
+        }
     }
 }

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -263,4 +263,45 @@ public sealed class PackageRegistryTests : LoggingTestBase
             Assert.Equal(expected: highestVersion, actual: found[TestPackageId]);
         }
     }
+
+    [Fact]
+    public async Task RegisterFoundPackageVersion_WhenCalledConcurrentlyForAnAbsentKey_NeverDropsTheHighestVersion()
+    {
+        PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
+        PackageSource source = CreateTestPackageSource();
+        NuGetVersion middleVersion = NuGetVersion.Parse("1.5.0");
+        NuGetVersion highestVersion = NuGetVersion.Parse("2.0.0");
+
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        for (int iteration = 0; iteration < 200; ++iteration)
+        {
+            ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+
+            await Task.WhenAll(
+                Task.Run(
+                    () =>
+                        registry.RegisterFoundPackageVersion(
+                            packageSource: source,
+                            found: found,
+                            packageId: TestPackageId,
+                            candidateVersion: highestVersion
+                        ),
+                    cancellationToken
+                ),
+                Task.Run(
+                    () =>
+                        registry.RegisterFoundPackageVersion(
+                            packageSource: source,
+                            found: found,
+                            packageId: TestPackageId,
+                            candidateVersion: middleVersion
+                        ),
+                    cancellationToken
+                )
+            );
+
+            Assert.Equal(expected: highestVersion, actual: found[TestPackageId]);
+        }
+    }
 }

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -66,10 +66,9 @@ public sealed class PackageRegistry : IPackageRegistry
         return new(source: source, $"Custom{sourceId}", isEnabled: true, isOfficial: true, isPersistable: true);
     }
 
-    private async Task LoadPackagesFromSourceAsync(
+    private async Task<IReadOnlyList<PackageVersion>> LoadPackagesFromSourceAsync(
         SourceRepository sourceRepository,
         string packageId,
-        ConcurrentDictionary<string, NuGetVersion> found,
         CancellationToken cancellationToken
     )
     {
@@ -79,55 +78,30 @@ public sealed class PackageRegistry : IPackageRegistry
             cancellationToken: cancellationToken
         );
 
-        foreach (
-            PackageVersion packageVersion in result
+        return
+        [
+            .. result
                 .Select(entry => entry.Identity)
                 .Select(identity => new PackageVersion(packageId: identity.Id, version: identity.Version))
-                .Where(p => !p.Version.IsPrerelease && !IsBannedPackage(p))
-        )
-        {
-            this.RegisterFoundPackageVersion(
-                packageSource: sourceRepository.PackageSource,
-                found: found,
-                packageId: packageVersion.PackageId,
-                candidateVersion: packageVersion.Version
-            );
-        }
+                .Where(p => !p.Version.IsPrerelease && !IsBannedPackage(p)),
+        ];
     }
 
+    // merged single-threaded after the Task.WhenAll barrier in FindPackageInSourcesAsync, so the
+    // highest candidate across sources is never dropped by a lost concurrent-write race (see #569).
     public void RegisterFoundPackageVersion(
         PackageSource packageSource,
-        ConcurrentDictionary<string, NuGetVersion> found,
+        IDictionary<string, NuGetVersion> found,
         string packageId,
         NuGetVersion candidateVersion
     )
     {
-        // pick the latest feed always; re-read and retry on a lost TryUpdate race instead of
-        // giving up, so a higher candidate is never dropped due to a stale read (see #569).
-        while (true)
+        if (found.TryGetValue(key: packageId, out NuGetVersion? existingVersion) && existingVersion >= candidateVersion)
         {
-            if (!found.TryGetValue(key: packageId, out NuGetVersion? existingVersion))
-            {
-                if (found.TryAdd(key: packageId, value: candidateVersion))
-                {
-                    break;
-                }
-
-                continue;
-            }
-
-            if (existingVersion >= candidateVersion)
-            {
-                return;
-            }
-
-            if (
-                found.TryUpdate(key: packageId, newValue: candidateVersion, comparisonValue: existingVersion)
-            )
-            {
-                break;
-            }
+            return;
         }
+
+        found[packageId] = candidateVersion;
 
         this._logger.FoundPackageInSource(
             packageId: packageId,
@@ -150,49 +124,27 @@ public sealed class PackageRegistry : IPackageRegistry
     {
         this._logger.EnumeratingPackageVersions(packageId);
 
-        ConcurrentDictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
-
-        Exception?[] failures = await Task.WhenAll(
+        (IReadOnlyList<PackageVersion> Found, Exception? Failure)[] outcomes = await Task.WhenAll(
             sourceRepositories.Select(selector: sourceRepository =>
                 this.LoadPackagesFromSourceSafeAsync(
                     sourceRepository: sourceRepository,
                     packageId: packageId,
-                    found: found,
                     cancellationToken: cancellationToken
                 )
             )
         );
 
-        if (failures.Any(failure => failure is not null))
+        if (outcomes.Any(outcome => outcome.Failure is not null))
         {
-            IReadOnlyList<(SourceRepository SourceRepository, Exception? Failure)> outcomes =
-            [
-                .. sourceRepositories.Zip(failures),
-            ];
-            IReadOnlyList<string> failedSources =
-            [
-                .. outcomes.Where(o => o.Failure is not null).Select(o => o.SourceRepository.PackageSource.Name),
-            ];
-            IReadOnlyList<string> succeededSources =
-            [
-                .. outcomes.Where(o => o.Failure is null).Select(o => o.SourceRepository.PackageSource.Name),
-            ];
-            string succeededSourcesMessage =
-                succeededSources.Count == 0 ? "(none)" : string.Join(separator: ", ", succeededSources);
-
-            this._logger.PackageSourcesFailed(
-                failedCount: failedSources.Count,
-                sourceCount: sourceRepositories.Count,
-                packageId: packageId,
-                failedSources: string.Join(separator: ", ", failedSources),
-                succeededSources: succeededSourcesMessage
-            );
-
-            throw new UpdateFailedException(
-                $"{failedSources.Count} of {sourceRepositories.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}. Succeeded: {succeededSourcesMessage}",
-                new AggregateException(failures.OfType<Exception>())
-            );
+            this.ThrowForFailedSources(sourceRepositories: sourceRepositories, packageId: packageId, outcomes: outcomes);
         }
+
+        // sources ran concurrently above; the Task.WhenAll barrier means every source's results are
+        // already collected by this point, so merging them here can run single-threaded (see #569).
+        Dictionary<string, NuGetVersion> found = this.MergeFoundVersions(
+            sourceRepositories: sourceRepositories,
+            outcomes: outcomes
+        );
 
         foreach ((string key, NuGetVersion value) in found)
         {
@@ -200,23 +152,84 @@ public sealed class PackageRegistry : IPackageRegistry
         }
     }
 
-    private async Task<Exception?> LoadPackagesFromSourceSafeAsync(
+    private Dictionary<string, NuGetVersion> MergeFoundVersions(
+        IReadOnlyList<SourceRepository> sourceRepositories,
+        (IReadOnlyList<PackageVersion> Found, Exception? Failure)[] outcomes
+    )
+    {
+        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+
+        for (int index = 0; index < sourceRepositories.Count; ++index)
+        {
+            PackageSource packageSource = sourceRepositories[index].PackageSource;
+
+            foreach (PackageVersion packageVersion in outcomes[index].Found)
+            {
+                this.RegisterFoundPackageVersion(
+                    packageSource: packageSource,
+                    found: found,
+                    packageId: packageVersion.PackageId,
+                    candidateVersion: packageVersion.Version
+                );
+            }
+        }
+
+        return found;
+    }
+
+    private void ThrowForFailedSources(
+        IReadOnlyList<SourceRepository> sourceRepositories,
+        string packageId,
+        (IReadOnlyList<PackageVersion> Found, Exception? Failure)[] outcomes
+    )
+    {
+        IReadOnlyList<(string SourceName, Exception? Failure)> namedOutcomes =
+        [
+            .. sourceRepositories.Zip(
+                outcomes,
+                (sourceRepository, outcome) => (sourceRepository.PackageSource.Name, outcome.Failure)
+            ),
+        ];
+        IReadOnlyList<string> failedSources =
+        [
+            .. namedOutcomes.Where(o => o.Failure is not null).Select(o => o.SourceName),
+        ];
+        IReadOnlyList<string> succeededSources =
+        [
+            .. namedOutcomes.Where(o => o.Failure is null).Select(o => o.SourceName),
+        ];
+        string succeededSourcesMessage =
+            succeededSources.Count == 0 ? "(none)" : string.Join(separator: ", ", succeededSources);
+
+        this._logger.PackageSourcesFailed(
+            failedCount: failedSources.Count,
+            sourceCount: sourceRepositories.Count,
+            packageId: packageId,
+            failedSources: string.Join(separator: ", ", failedSources),
+            succeededSources: succeededSourcesMessage
+        );
+
+        throw new UpdateFailedException(
+            $"{failedSources.Count} of {sourceRepositories.Count} package source(s) failed while looking up {packageId}: {string.Join(separator: ", ", failedSources)}. Succeeded: {succeededSourcesMessage}",
+            new AggregateException(outcomes.Select(outcome => outcome.Failure).OfType<Exception>())
+        );
+    }
+
+    private async Task<(IReadOnlyList<PackageVersion> Found, Exception? Failure)> LoadPackagesFromSourceSafeAsync(
         SourceRepository sourceRepository,
         string packageId,
-        ConcurrentDictionary<string, NuGetVersion> found,
         CancellationToken cancellationToken
     )
     {
         try
         {
-            await this.LoadPackagesFromSourceAsync(
+            IReadOnlyList<PackageVersion> found = await this.LoadPackagesFromSourceAsync(
                 sourceRepository: sourceRepository,
                 packageId: packageId,
-                found: found,
                 cancellationToken: cancellationToken
             );
 
-            return null;
+            return (found, null);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -231,7 +244,7 @@ public sealed class PackageRegistry : IPackageRegistry
                 exception: exception
             );
 
-            return exception;
+            return ([], exception);
         }
     }
 }

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -86,49 +86,54 @@ public sealed class PackageRegistry : IPackageRegistry
                 .Where(p => !p.Version.IsPrerelease && !IsBannedPackage(p))
         )
         {
-            if (found.TryGetValue(key: packageVersion.PackageId, out NuGetVersion? existingVersion))
-            {
-                this.DoUpdateRegisteredFoundPackage(
-                    packageSource: sourceRepository.PackageSource,
-                    found: found,
-                    existingVersion: existingVersion,
-                    packageVersion: packageVersion
-                );
-            }
-            else if (found.TryAdd(key: packageVersion.PackageId, value: packageVersion.Version))
-            {
-                this._logger.FoundPackageInSource(
-                    packageId: packageVersion.PackageId,
-                    version: packageVersion.Version,
-                    source: sourceRepository.PackageSource.Source
-                );
-            }
+            this.RegisterFoundPackageVersion(
+                packageSource: sourceRepository.PackageSource,
+                found: found,
+                packageId: packageVersion.PackageId,
+                candidateVersion: packageVersion.Version
+            );
         }
     }
 
-    private void DoUpdateRegisteredFoundPackage(
+    public void RegisterFoundPackageVersion(
         PackageSource packageSource,
         ConcurrentDictionary<string, NuGetVersion> found,
-        NuGetVersion existingVersion,
-        PackageVersion packageVersion
+        string packageId,
+        NuGetVersion candidateVersion
     )
     {
-        // pick the latest feed always
-        if (
-            existingVersion < packageVersion.Version
-            && found.TryUpdate(
-                key: packageVersion.PackageId,
-                newValue: packageVersion.Version,
-                comparisonValue: existingVersion
-            )
-        )
+        // pick the latest feed always; re-read and retry on a lost TryUpdate race instead of
+        // giving up, so a higher candidate is never dropped due to a stale read (see #569).
+        while (true)
         {
-            this._logger.FoundPackageInSource(
-                packageId: packageVersion.PackageId,
-                version: packageVersion.Version,
-                source: packageSource.Source
-            );
+            if (!found.TryGetValue(key: packageId, out NuGetVersion? existingVersion))
+            {
+                if (found.TryAdd(key: packageId, value: candidateVersion))
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (existingVersion >= candidateVersion)
+            {
+                return;
+            }
+
+            if (
+                found.TryUpdate(key: packageId, newValue: candidateVersion, comparisonValue: existingVersion)
+            )
+            {
+                break;
+            }
         }
+
+        this._logger.FoundPackageInSource(
+            packageId: packageId,
+            version: candidateVersion,
+            source: packageSource.Source
+        );
     }
 
     private static bool IsBannedPackage(PackageVersion packageVersion)


### PR DESCRIPTION
## Summary

`PackageRegistry.DoUpdateRegisteredFoundPackage` resolved version conflicts across NuGet feeds with a read-then-`TryUpdate` compare-and-swap. Because all sources are queried concurrently, a losing `TryUpdate` returned without retrying, silently dropping a candidate version even when it was higher than the value that won the race.

Replaced the racy `TryGetValue`/`TryUpdate`/`TryAdd` branches with a single `RegisterFoundPackageVersion` method that loops: re-reading the current value and retrying the comparison after a lost `TryUpdate` race, so the highest version reported by any source always wins. `RegisterFoundPackageVersion` is `public` on the already-public `PackageRegistry` class so it is directly unit-testable without networking.

Note: the originally posted plan proposed `ConcurrentDictionary.AddOrUpdate` with a max-of-both update factory, but the repo's `FunFair.CodeAnalysis` analyzer (FFS0032) forbids the built-in `AddOrUpdate` overloads, and `FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate` (the analyzer's suggested replacement) only supports unconditional-set semantics, not a max-of-both comparison. Implemented the alternative fix explicitly sanctioned by the original issue text instead: a manual retry loop using `TryGetValue`/`TryAdd`/`TryUpdate`.

## Test plan

- [x] Added `PackageRegistryTests` covering: add when absent, higher/lower/equal candidate against an existing value (parameterised), and a 200-iteration concurrency test proving the highest of two racing versions always wins.
- [x] `dotnet build` succeeds with 0 warnings/errors.
- [x] `dotnet test` passes: 430/430 (194 in `Credfeto.Package.Tests`, including 5 new tests run against 2 target frameworks each).
- [x] `pre-commit --all-files` and the staged pre-commit hook both pass end-to-end (lint, buildcheck, build, test, publish, pack).

Closes #569