### PR TITLE
fix: use case-insensitive comparer when merging package versions across feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - NuGet source failures during package updates are now reported individually, naming every failed source and reason, instead of a single opaque exception
 - Concurrent package version lookups across NuGet feeds no longer silently drop the highest version when two feeds race to update the same package
 - Saved .csproj files now always end with exactly one newline, matching pre-commit's end-of-file-fixer expectation
+- Package version lookups no longer pick an older version when NuGet feeds disagree on package-id casing
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -46,6 +46,25 @@ public sealed class PackageRegistryTests : LoggingTestBase
         return [metadata];
     }
 
+    private static void MockPackageMetadataFetcherGetMetadata(
+        IPackageMetadataFetcher metadataFetcher,
+        string sourceUrl,
+        string requestedPackageId,
+        string returnedPackageId,
+        string version
+    )
+    {
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, sourceUrl)
+                ),
+                packageId: requestedPackageId,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: returnedPackageId, version: version)));
+    }
+
     private static (string FailedPart, string SucceededPart) SplitOnSucceeded(string message)
     {
         const string marker = "Succeeded: ";
@@ -72,15 +91,13 @@ public sealed class PackageRegistryTests : LoggingTestBase
                 Task.FromException<IEnumerable<IPackageSearchMetadata>>(new HttpRequestException("feed unreachable"))
             );
 
-        metadataFetcher
-            .GetMetadataAsync(
-                Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
-                ),
-                packageId: "Test.Package",
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.2.3")));
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: AliveSourceUrl,
+            requestedPackageId: "Test.Package",
+            returnedPackageId: "Test.Package",
+            version: "1.2.3"
+        );
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 
@@ -185,25 +202,20 @@ public sealed class PackageRegistryTests : LoggingTestBase
     {
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
-        metadataFetcher
-            .GetMetadataAsync(
-                Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
-                ),
-                packageId: "Test.Package",
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "1.5.0")));
-
-        metadataFetcher
-            .GetMetadataAsync(
-                Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl2)
-                ),
-                packageId: "Test.Package",
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Test.Package", version: "2.0.0")));
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: AliveSourceUrl,
+            requestedPackageId: "Test.Package",
+            returnedPackageId: "Test.Package",
+            version: "1.5.0"
+        );
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: DeadSourceUrl2,
+            requestedPackageId: "Test.Package",
+            returnedPackageId: "Test.Package",
+            version: "2.0.0"
+        );
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 
@@ -223,25 +235,20 @@ public sealed class PackageRegistryTests : LoggingTestBase
     {
         IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
 
-        metadataFetcher
-            .GetMetadataAsync(
-                Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
-                ),
-                packageId: "Foo.Bar",
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Foo.Bar", version: "1.0.0")));
-
-        metadataFetcher
-            .GetMetadataAsync(
-                Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl2)
-                ),
-                packageId: "Foo.Bar",
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(_ => Task.FromResult(MetadataFor(packageId: "foo.bar", version: "2.0.0")));
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: AliveSourceUrl,
+            requestedPackageId: "Foo.Bar",
+            returnedPackageId: "Foo.Bar",
+            version: "1.0.0"
+        );
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: DeadSourceUrl2,
+            requestedPackageId: "Foo.Bar",
+            returnedPackageId: "foo.bar",
+            version: "2.0.0"
+        );
 
         PackageRegistry registry = this.CreateRegistry(metadataFetcher);
 

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -219,6 +219,43 @@ public sealed class PackageRegistryTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task FindPackagesAsync_WhenSourcesDisagreeOnPackageIdCasing_ReturnsTheHighestVersion()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, AliveSourceUrl)
+                ),
+                packageId: "Foo.Bar",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "Foo.Bar", version: "1.0.0")));
+
+        metadataFetcher
+            .GetMetadataAsync(
+                Arg.Is<SourceRepository>(sourceRepository =>
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl2)
+                ),
+                packageId: "Foo.Bar",
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => Task.FromResult(MetadataFor(packageId: "foo.bar", version: "2.0.0")));
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
+            packageIds: ["Foo.Bar"],
+            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: NuGetVersion.Parse("2.0.0"), actual: found.Version);
+    }
+
+    [Fact]
     public void RegisterFoundPackageVersion_WhenKeyNotPresent_AddsCandidate()
     {
         Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -157,7 +157,7 @@ public sealed class PackageRegistry : IPackageRegistry
         (IReadOnlyList<PackageVersion> Found, Exception? Failure)[] outcomes
     )
     {
-        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+        Dictionary<string, NuGetVersion> found = new(StringComparer.OrdinalIgnoreCase);
 
         for (int index = 0; index < sourceRepositories.Count; ++index)
         {


### PR DESCRIPTION
## Summary

- `PackageRegistry.MergeFoundVersions` created its `found` dictionary with `StringComparer.Ordinal`, while every other package-id dictionary in the file (including the `packages` dictionary results are merged into) uses `StringComparer.OrdinalIgnoreCase`.
- Package ids are matched case-insensitively elsewhere in this file, and different NuGet feeds can return the same package with different canonical casing (e.g. `newtonsoft.json` vs `Newtonsoft.Json`). With the ordinal comparer, these became two separate dictionary entries, so `RegisterFoundPackageVersion`'s "keep the highest version across feeds" logic never ran between them - whichever casing was enumerated first won, even if it held the older version.
- Fixed by creating `found` with `StringComparer.OrdinalIgnoreCase`.

Closes #570

## Test plan

- [x] Added `PackageRegistryTests.FindPackagesAsync_WhenSourcesDisagreeOnPackageIdCasing_ReturnsTheHighestVersion` - two sources return `Foo.Bar 1.0.0` and `foo.bar 2.0.0`; asserts the merged result is `2.0.0`.
- [x] Verified the new test fails against the pre-fix code (reproduces the bug: picks `1.0.0`) and passes with the fix.
- [x] `dotnet test` on `Credfeto.Package.Tests` - 198 tests passed (net9.0 + net10.0).
- [x] Full pre-commit baseline passed, including build, tests, publish, and pack.
