### PR TITLE
fix: preserve winning source's package id casing in merged versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Concurrent package version lookups across NuGet feeds no longer silently drop the highest version when two feeds race to update the same package
 - Saved .csproj files now always end with exactly one newline, matching pre-commit's end-of-file-fixer expectation
 - Package version lookups no longer pick an older version when NuGet feeds disagree on package-id casing
+- Merged package versions across NuGet feeds now keep the package id casing of whichever feed supplied the winning version, in both the live registry lookup and the on-disk version cache
 ### Changed
 - Updated DotNet SDK to 10.0.300
 - Renamed Credfeto.Package.Test to Credfeto.Package.Tests to follow the .Tests naming convention

--- a/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
@@ -103,6 +103,40 @@ public sealed class PackageCacheTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public void SetVersions_WhenHigherVersionArrivesWithDifferentCasing_UsesWinningCasing()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion v1 = new(packageId: "Foo.Bar", version: new NuGetVersion("1.0.0"));
+        PackageVersion v2 = new(packageId: "foo.bar", version: new NuGetVersion("2.0.0"));
+
+        cache.SetVersions([v1]);
+        cache.SetVersions([v2]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetAll();
+
+        Assert.Single(result);
+        Assert.Equal(expected: "foo.bar", actual: result[0].PackageId);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: result[0].Version);
+    }
+
+    [Fact]
+    public void SetVersions_WhenLowerVersionArrivesWithDifferentCasing_KeepsExistingCasing()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion v2 = new(packageId: "Foo.Bar", version: new NuGetVersion("2.0.0"));
+        PackageVersion v1 = new(packageId: "foo.bar", version: new NuGetVersion("1.0.0"));
+
+        cache.SetVersions([v2]);
+        cache.SetVersions([v1]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetAll();
+
+        Assert.Single(result);
+        Assert.Equal(expected: "Foo.Bar", actual: result[0].PackageId);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: result[0].Version);
+    }
+
+    [Fact]
     public void Reset_ClearsCache()
     {
         PackageCache cache = this.CreateCache();
@@ -196,5 +230,27 @@ public sealed class PackageCacheTests : LoggingFolderCleanupTestBase
         Assert.Single(result);
         Assert.Equal(expected: "TestPackage", actual: result[0].PackageId);
         Assert.Equal(expected: new NuGetVersion("1.0.0"), actual: result[0].Version);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenLoadAsync_RoundTripsWinningCasing()
+    {
+        string filePath = Path.Combine(this.TempFolder, "cache-casing-round-trip.json");
+
+        PackageCache saveCache = this.CreateCache();
+        PackageVersion v1 = new(packageId: "Foo.Bar", version: new NuGetVersion("1.0.0"));
+        PackageVersion v2 = new(packageId: "foo.bar", version: new NuGetVersion("2.0.0"));
+        saveCache.SetVersions([v1]);
+        saveCache.SetVersions([v2]);
+
+        await saveCache.SaveAsync(fileName: filePath, cancellationToken: this.CancellationToken());
+
+        PackageCache loadCache = this.CreateCache();
+        await loadCache.LoadAsync(fileName: filePath, cancellationToken: this.CancellationToken());
+
+        IReadOnlyList<PackageVersion> result = loadCache.GetAll();
+        Assert.Single(result);
+        Assert.Equal(expected: "foo.bar", actual: result[0].PackageId);
+        Assert.Equal(expected: new NuGetVersion("2.0.0"), actual: result[0].Version);
     }
 }

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -18,10 +18,10 @@ namespace Credfeto.Package.Tests.Services;
 
 public sealed class PackageRegistryTests : LoggingTestBase
 {
-    private const string DeadSourceUrl = "https://dead.example/index.json";
-    private const string AliveSourceUrl = "https://alive.example/index.json";
-    private const string DeadSourceUrl2 = "https://dead-two.example/index.json";
-    private const string TestPackageId = "Test.Package";
+    private const string DEAD_SOURCE_URL = "https://dead.example/index.json";
+    private const string ALIVE_SOURCE_URL = "https://alive.example/index.json";
+    private const string DEAD_SOURCE_URL_2 = "https://dead-two.example/index.json";
+    private const string TEST_PACKAGE_ID = "Test.Package";
 
     public PackageRegistryTests(ITestOutputHelper output)
         : base(output) { }
@@ -35,7 +35,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
     private static PackageSource CreateTestPackageSource()
     {
-        return new(source: AliveSourceUrl, name: "Alive", isEnabled: true, isOfficial: true, isPersistable: true);
+        return new(source: ALIVE_SOURCE_URL, name: "Alive", isEnabled: true, isOfficial: true, isPersistable: true);
     }
 
     private static IEnumerable<IPackageSearchMetadata> MetadataFor(string packageId, string version)
@@ -82,7 +82,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
         metadataFetcher
             .GetMetadataAsync(
                 Arg.Is<SourceRepository>(sourceRepository =>
-                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DeadSourceUrl)
+                    StringComparer.Ordinal.Equals(sourceRepository.PackageSource.Source, DEAD_SOURCE_URL)
                 ),
                 packageId: "Test.Package",
                 Arg.Any<CancellationToken>()
@@ -93,7 +93,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: AliveSourceUrl,
+            sourceUrl: ALIVE_SOURCE_URL,
             requestedPackageId: "Test.Package",
             returnedPackageId: "Test.Package",
             version: "1.2.3"
@@ -105,7 +105,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
             registry
                 .FindPackagesAsync(
                     packageIds: ["Test.Package"],
-                    packageSources: [DeadSourceUrl, AliveSourceUrl],
+                    packageSources: [DEAD_SOURCE_URL, ALIVE_SOURCE_URL],
                     cancellationToken: this.CancellationToken()
                 )
                 .AsTask()
@@ -152,7 +152,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
             registry
                 .FindPackagesAsync(
                     packageIds: ["Test.Package"],
-                    packageSources: [DeadSourceUrl, DeadSourceUrl2],
+                    packageSources: [DEAD_SOURCE_URL, DEAD_SOURCE_URL_2],
                     cancellationToken: this.CancellationToken()
                 )
                 .AsTask()
@@ -188,7 +188,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
             packageIds: ["Test.Package"],
-            packageSources: [AliveSourceUrl],
+            packageSources: [ALIVE_SOURCE_URL],
             cancellationToken: this.CancellationToken()
         );
 
@@ -204,14 +204,14 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: AliveSourceUrl,
+            sourceUrl: ALIVE_SOURCE_URL,
             requestedPackageId: "Test.Package",
             returnedPackageId: "Test.Package",
             version: "1.5.0"
         );
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: DeadSourceUrl2,
+            sourceUrl: DEAD_SOURCE_URL_2,
             requestedPackageId: "Test.Package",
             returnedPackageId: "Test.Package",
             version: "2.0.0"
@@ -221,7 +221,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
             packageIds: ["Test.Package"],
-            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            packageSources: [ALIVE_SOURCE_URL, DEAD_SOURCE_URL_2],
             cancellationToken: this.CancellationToken()
         );
 
@@ -237,14 +237,14 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: AliveSourceUrl,
+            sourceUrl: ALIVE_SOURCE_URL,
             requestedPackageId: "Foo.Bar",
             returnedPackageId: "Foo.Bar",
             version: "1.0.0"
         );
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: DeadSourceUrl2,
+            sourceUrl: DEAD_SOURCE_URL_2,
             requestedPackageId: "Foo.Bar",
             returnedPackageId: "foo.bar",
             version: "2.0.0"
@@ -254,7 +254,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
             packageIds: ["Foo.Bar"],
-            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            packageSources: [ALIVE_SOURCE_URL, DEAD_SOURCE_URL_2],
             cancellationToken: this.CancellationToken()
         );
 
@@ -270,14 +270,14 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: AliveSourceUrl,
+            sourceUrl: ALIVE_SOURCE_URL,
             requestedPackageId: "Foo.Bar",
             returnedPackageId: "Foo.Bar",
             version: "2.0.0"
         );
         MockPackageMetadataFetcherGetMetadata(
             metadataFetcher,
-            sourceUrl: DeadSourceUrl2,
+            sourceUrl: DEAD_SOURCE_URL_2,
             requestedPackageId: "Foo.Bar",
             returnedPackageId: "foo.bar",
             version: "1.0.0"
@@ -287,7 +287,7 @@ public sealed class PackageRegistryTests : LoggingTestBase
 
         IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
             packageIds: ["Foo.Bar"],
-            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            packageSources: [ALIVE_SOURCE_URL, DEAD_SOURCE_URL_2],
             cancellationToken: this.CancellationToken()
         );
 
@@ -305,10 +305,10 @@ public sealed class PackageRegistryTests : LoggingTestBase
         registry.RegisterFoundPackageVersion(
             packageSource: CreateTestPackageSource(),
             found: found,
-            candidate: new PackageVersion(packageId: TestPackageId, NuGetVersion.Parse("1.2.3"))
+            candidate: new PackageVersion(packageId: TEST_PACKAGE_ID, NuGetVersion.Parse("1.2.3"))
         );
 
-        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found[TestPackageId].Version);
+        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found[TEST_PACKAGE_ID].Version);
     }
 
     [Theory]
@@ -323,16 +323,16 @@ public sealed class PackageRegistryTests : LoggingTestBase
     {
         Dictionary<string, PackageVersion> found = new(StringComparer.Ordinal)
         {
-            [TestPackageId] = new(packageId: TestPackageId, NuGetVersion.Parse(existing)),
+            [TEST_PACKAGE_ID] = new(packageId: TEST_PACKAGE_ID, NuGetVersion.Parse(existing)),
         };
         PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
 
         registry.RegisterFoundPackageVersion(
             packageSource: CreateTestPackageSource(),
             found: found,
-            candidate: new PackageVersion(packageId: TestPackageId, NuGetVersion.Parse(candidate))
+            candidate: new PackageVersion(packageId: TEST_PACKAGE_ID, NuGetVersion.Parse(candidate))
         );
 
-        Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TestPackageId].Version);
+        Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TEST_PACKAGE_ID].Version);
     }
 }

--- a/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageRegistryTests.cs
@@ -259,23 +259,56 @@ public sealed class PackageRegistryTests : LoggingTestBase
         );
 
         PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: "foo.bar", actual: found.PackageId);
+        Assert.Equal(expected: NuGetVersion.Parse("2.0.0"), actual: found.Version);
+    }
+
+    [Fact]
+    public async Task FindPackagesAsync_WhenLaterSourceHasLowerVersionWithDifferentCasing_KeepsWinnerCasing()
+    {
+        IPackageMetadataFetcher metadataFetcher = GetSubstitute<IPackageMetadataFetcher>();
+
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: AliveSourceUrl,
+            requestedPackageId: "Foo.Bar",
+            returnedPackageId: "Foo.Bar",
+            version: "2.0.0"
+        );
+        MockPackageMetadataFetcherGetMetadata(
+            metadataFetcher,
+            sourceUrl: DeadSourceUrl2,
+            requestedPackageId: "Foo.Bar",
+            returnedPackageId: "foo.bar",
+            version: "1.0.0"
+        );
+
+        PackageRegistry registry = this.CreateRegistry(metadataFetcher);
+
+        IReadOnlyList<PackageVersion> result = await registry.FindPackagesAsync(
+            packageIds: ["Foo.Bar"],
+            packageSources: [AliveSourceUrl, DeadSourceUrl2],
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageVersion found = Assert.Single(result);
+        Assert.Equal(expected: "Foo.Bar", actual: found.PackageId);
         Assert.Equal(expected: NuGetVersion.Parse("2.0.0"), actual: found.Version);
     }
 
     [Fact]
     public void RegisterFoundPackageVersion_WhenKeyNotPresent_AddsCandidate()
     {
-        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal);
+        Dictionary<string, PackageVersion> found = new(StringComparer.Ordinal);
         PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
 
         registry.RegisterFoundPackageVersion(
             packageSource: CreateTestPackageSource(),
             found: found,
-            packageId: TestPackageId,
-            candidateVersion: NuGetVersion.Parse("1.2.3")
+            candidate: new PackageVersion(packageId: TestPackageId, NuGetVersion.Parse("1.2.3"))
         );
 
-        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found[TestPackageId]);
+        Assert.Equal(expected: NuGetVersion.Parse("1.2.3"), actual: found[TestPackageId].Version);
     }
 
     [Theory]
@@ -288,16 +321,18 @@ public sealed class PackageRegistryTests : LoggingTestBase
         string expected
     )
     {
-        Dictionary<string, NuGetVersion> found = new(StringComparer.Ordinal) { [TestPackageId] = NuGetVersion.Parse(existing) };
+        Dictionary<string, PackageVersion> found = new(StringComparer.Ordinal)
+        {
+            [TestPackageId] = new(packageId: TestPackageId, NuGetVersion.Parse(existing)),
+        };
         PackageRegistry registry = this.CreateRegistry(GetSubstitute<IPackageMetadataFetcher>());
 
         registry.RegisterFoundPackageVersion(
             packageSource: CreateTestPackageSource(),
             found: found,
-            packageId: TestPackageId,
-            candidateVersion: NuGetVersion.Parse(candidate)
+            candidate: new PackageVersion(packageId: TestPackageId, NuGetVersion.Parse(candidate))
         );
 
-        Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TestPackageId]);
+        Assert.Equal(expected: NuGetVersion.Parse(expected), actual: found[TestPackageId].Version);
     }
 }

--- a/src/Credfeto.Package/Services/PackageCache.cs
+++ b/src/Credfeto.Package/Services/PackageCache.cs
@@ -17,7 +17,7 @@ namespace Credfeto.Package.Services;
 
 public sealed class PackageCache : IPackageCache
 {
-    private readonly ConcurrentDictionary<string, NuGetVersion> _cache;
+    private readonly ConcurrentDictionary<string, PackageVersion> _cache;
     private readonly ILogger<PackageCache> _logger;
     private readonly JsonTypeInfo<CacheItems> _typeInfo;
     private bool _changed;
@@ -51,7 +51,10 @@ public sealed class PackageCache : IPackageCache
             )
             {
                 this._logger.LoadedPackageVersionFromCache(packageId: packageId, version: version);
-                this._cache.TryAdd(key: packageId, NuGetVersion.Parse(version));
+                this._cache.TryAdd(
+                    key: packageId,
+                    new PackageVersion(packageId: packageId, version: NuGetVersion.Parse(version))
+                );
             }
         }
     }
@@ -65,10 +68,12 @@ public sealed class PackageCache : IPackageCache
 
         this._logger.SavingCache(fileName);
 
+        // key off the value's package id, not the dictionary key - the key text is frozen to whichever
+        // source was merged first, while the value always carries the winning source's casing (see #595)
         CacheItems toWrite = new(
             this._cache.ToDictionary(
-                keySelector: x => x.Key,
-                elementSelector: x => x.Value.ToString(),
+                keySelector: x => x.Value.PackageId,
+                elementSelector: x => x.Value.Version.ToString(),
                 comparer: StringComparer.OrdinalIgnoreCase
             )
         );
@@ -105,9 +110,9 @@ public sealed class PackageCache : IPackageCache
         this._cache.Clear();
     }
 
-    private static IReadOnlyList<PackageVersion> BuildVersions(IEnumerable<KeyValuePair<string, NuGetVersion>> source)
+    private static IReadOnlyList<PackageVersion> BuildVersions(IEnumerable<KeyValuePair<string, PackageVersion>> source)
     {
-        return [.. source.Select(x => new PackageVersion(packageId: x.Key, version: x.Value))];
+        return [.. source.Select(x => x.Value)];
     }
 
     [DoesNotReturn]
@@ -118,30 +123,27 @@ public sealed class PackageCache : IPackageCache
 
     private void UpdateCache(PackageVersion packageVersion)
     {
-        if (this._cache.TryGetValue(key: packageVersion.PackageId, out NuGetVersion? existing))
+        if (this._cache.TryGetValue(key: packageVersion.PackageId, out PackageVersion? existing))
         {
-            if (existing < packageVersion.Version)
+            if (existing.Version < packageVersion.Version)
             {
-                if (
-                    this._cache.TryUpdate(
-                        key: packageVersion.PackageId,
-                        newValue: packageVersion.Version,
-                        comparisonValue: existing
-                    )
-                )
-                {
-                    this._logger.UpdatingPackageVersion(
-                        packageId: packageVersion.PackageId,
-                        existing: existing,
-                        version: packageVersion.Version
-                    );
-                    this._changed = true;
-                }
+                // plain indexer set, not TryUpdate's compare-and-swap: PackageVersion equality compares
+                // PackageId only (ignoring Version), so a version-based CAS comparisonValue would no
+                // longer mean what it looks like. Safe because SetVersions/UpdateCache is only ever
+                // called sequentially from PackageUpdater.UpdateAsync - no concurrent writers.
+                this._cache[packageVersion.PackageId] = packageVersion;
+
+                this._logger.UpdatingPackageVersion(
+                    packageId: packageVersion.PackageId,
+                    existing: existing.Version,
+                    version: packageVersion.Version
+                );
+                this._changed = true;
             }
         }
         else
         {
-            if (this._cache.TryAdd(key: packageVersion.PackageId, value: packageVersion.Version))
+            if (this._cache.TryAdd(key: packageVersion.PackageId, value: packageVersion))
             {
                 this._logger.AddingPackageToCache(packageId: packageVersion.PackageId, version: packageVersion.Version);
                 this._changed = true;

--- a/src/Credfeto.Package/Services/PackageCache.cs
+++ b/src/Credfeto.Package/Services/PackageCache.cs
@@ -143,11 +143,10 @@ public sealed class PackageCache : IPackageCache
         }
         else
         {
-            if (this._cache.TryAdd(key: packageVersion.PackageId, value: packageVersion))
-            {
-                this._logger.AddingPackageToCache(packageId: packageVersion.PackageId, version: packageVersion.Version);
-                this._changed = true;
-            }
+            // single-threaded per the comment above, so TryAdd cannot fail here - no need to guard it
+            this._cache.TryAdd(key: packageVersion.PackageId, value: packageVersion);
+            this._logger.AddingPackageToCache(packageId: packageVersion.PackageId, version: packageVersion.Version);
+            this._changed = true;
         }
     }
 }

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -32,7 +32,7 @@ public sealed class PackageRegistry : IPackageRegistry
     {
         IReadOnlyList<SourceRepository> sourceRepositories = DefineSourceRepositories(packageSources);
 
-        ConcurrentDictionary<string, NuGetVersion> packages = new(StringComparer.OrdinalIgnoreCase);
+        ConcurrentDictionary<string, PackageVersion> packages = new(StringComparer.OrdinalIgnoreCase);
 
         foreach (string packageId in packageIds)
         {
@@ -44,7 +44,7 @@ public sealed class PackageRegistry : IPackageRegistry
             );
         }
 
-        return [.. packages.Select(p => new PackageVersion(packageId: p.Key, version: p.Value))];
+        return [.. packages.Values];
     }
 
     private static IReadOnlyList<SourceRepository> DefineSourceRepositories(IReadOnlyList<string> sources)
@@ -89,23 +89,26 @@ public sealed class PackageRegistry : IPackageRegistry
 
     // merged single-threaded after the Task.WhenAll barrier in FindPackageInSourcesAsync, so the
     // highest candidate across sources is never dropped by a lost concurrent-write race (see #569).
+    // Stores the whole candidate (not just its version) so the winning source's package id casing
+    // travels with the value - a dictionary's key text never updates on a same-key write, only the
+    // value does, so reading id casing back out of the key would silently keep whichever source was
+    // merged first instead of whichever source actually won on version (see #595).
     public void RegisterFoundPackageVersion(
         PackageSource packageSource,
-        IDictionary<string, NuGetVersion> found,
-        string packageId,
-        NuGetVersion candidateVersion
+        IDictionary<string, PackageVersion> found,
+        PackageVersion candidate
     )
     {
-        if (found.TryGetValue(key: packageId, out NuGetVersion? existingVersion) && existingVersion >= candidateVersion)
+        if (found.TryGetValue(key: candidate.PackageId, out PackageVersion? existing) && existing.Version >= candidate.Version)
         {
             return;
         }
 
-        found[packageId] = candidateVersion;
+        found[candidate.PackageId] = candidate;
 
         this._logger.FoundPackageInSource(
-            packageId: packageId,
-            version: candidateVersion,
+            packageId: candidate.PackageId,
+            version: candidate.Version,
             source: packageSource.Source
         );
     }
@@ -118,7 +121,7 @@ public sealed class PackageRegistry : IPackageRegistry
     private async ValueTask FindPackageInSourcesAsync(
         IReadOnlyList<SourceRepository> sourceRepositories,
         string packageId,
-        ConcurrentDictionary<string, NuGetVersion> packages,
+        ConcurrentDictionary<string, PackageVersion> packages,
         CancellationToken cancellationToken
     )
     {
@@ -141,23 +144,23 @@ public sealed class PackageRegistry : IPackageRegistry
 
         // sources ran concurrently above; the Task.WhenAll barrier means every source's results are
         // already collected by this point, so merging them here can run single-threaded (see #569).
-        Dictionary<string, NuGetVersion> found = this.MergeFoundVersions(
+        Dictionary<string, PackageVersion> found = this.MergeFoundVersions(
             sourceRepositories: sourceRepositories,
             outcomes: outcomes
         );
 
-        foreach ((string key, NuGetVersion value) in found)
+        foreach (PackageVersion value in found.Values)
         {
-            packages.TryAdd(key: key, value: value);
+            packages.TryAdd(key: value.PackageId, value: value);
         }
     }
 
-    private Dictionary<string, NuGetVersion> MergeFoundVersions(
+    private Dictionary<string, PackageVersion> MergeFoundVersions(
         IReadOnlyList<SourceRepository> sourceRepositories,
         (IReadOnlyList<PackageVersion> Found, Exception? Failure)[] outcomes
     )
     {
-        Dictionary<string, NuGetVersion> found = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, PackageVersion> found = new(StringComparer.OrdinalIgnoreCase);
 
         for (int index = 0; index < sourceRepositories.Count; ++index)
         {
@@ -165,12 +168,7 @@ public sealed class PackageRegistry : IPackageRegistry
 
             foreach (PackageVersion packageVersion in outcomes[index].Found)
             {
-                this.RegisterFoundPackageVersion(
-                    packageSource: packageSource,
-                    found: found,
-                    packageId: packageVersion.PackageId,
-                    candidateVersion: packageVersion.Version
-                );
+                this.RegisterFoundPackageVersion(packageSource: packageSource, found: found, candidate: packageVersion);
             }
         }
 

--- a/src/Credfeto.Package/Services/PackageRegistry.cs
+++ b/src/Credfeto.Package/Services/PackageRegistry.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using NonBlocking;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 
 namespace Credfeto.Package.Services;
 
@@ -99,7 +98,10 @@ public sealed class PackageRegistry : IPackageRegistry
         PackageVersion candidate
     )
     {
-        if (found.TryGetValue(key: candidate.PackageId, out PackageVersion? existing) && existing.Version >= candidate.Version)
+        if (
+            found.TryGetValue(key: candidate.PackageId, out PackageVersion? existing)
+            && existing.Version >= candidate.Version
+        )
         {
             return;
         }
@@ -139,7 +141,11 @@ public sealed class PackageRegistry : IPackageRegistry
 
         if (outcomes.Any(outcome => outcome.Failure is not null))
         {
-            this.ThrowForFailedSources(sourceRepositories: sourceRepositories, packageId: packageId, outcomes: outcomes);
+            this.ThrowForFailedSources(
+                sourceRepositories: sourceRepositories,
+                packageId: packageId,
+                outcomes: outcomes
+            );
         }
 
         // sources ran concurrently above; the Task.WhenAll barrier means every source's results are


### PR DESCRIPTION
## Summary

- `Dictionary`/`ConcurrentDictionary` indexer-set and `TryUpdate` only ever update the stored *value* when a key already exists (case-insensitively) - they never rewrite the stored *key* text. So the final `PackageId` casing returned by both `PackageRegistry.FindPackagesAsync` and `PackageCache.GetAll`/`GetVersions` was whichever source/call was processed first, not the one that actually supplied the winning (highest) version.
- That casing flows straight into generated `.csproj` files via `Project.UpdatePackageFromReference`/`UpdatePackageFromSdk`, silently rewriting `Include=`/`Sdk=` attribute casing as a side effect of an unrelated version bump.
- Fixed by changing each affected dictionary's value type from `NuGetVersion` to `PackageVersion`, so the value itself carries the correctly-cased id alongside the version, and reading `PackageId` from the value everywhere instead of from the dictionary key.
- Two independent instances of the same bug class, both fixed:
  - `PackageRegistry.RegisterFoundPackageVersion`/`MergeFoundVersions`/`FindPackagesAsync`
  - `PackageCache._cache`/`UpdateCache`/`BuildVersions`/`SaveAsync` (also fixes the on-disk cache round-trip, so a stale casing can't resurface on a later run even after `PackageRegistry` alone is fixed)

Closes #595

## Test plan

- [x] Strengthened `FindPackagesAsync_WhenSourcesDisagreeOnPackageIdCasing_ReturnsTheHighestVersion` (from #570) with a `PackageId` assertion - previously only checked `.Version`.
- [x] Added `FindPackagesAsync_WhenLaterSourceHasLowerVersionWithDifferentCasing_KeepsWinnerCasing` - guards against a naive "last-processed casing wins" mis-fix.
- [x] Added `SetVersions_WhenHigherVersionArrivesWithDifferentCasing_UsesWinningCasing` and `SetVersions_WhenLowerVersionArrivesWithDifferentCasing_KeepsExistingCasing` to `PackageCacheTests.cs`.
- [x] Added `SaveAsync_ThenLoadAsync_RoundTripsWinningCasing` - proves the `SaveAsync` keySelector fix specifically (the persisted file would otherwise carry the losing casing).
- [x] Updated `RegisterFoundPackageVersion_WhenKeyNotPresent_AddsCandidate`/`RegisterFoundPackageVersion_WhenKeyAlreadyPresent_KeepsTheHigherVersion` for the new signature.
- [x] `dotnet test` on the full solution - 442 tests passed (net9.0 + net10.0).
- [x] `dotnet buildcheck` and the full pre-commit baseline passed.
