### PR TITLE
chore: drop net9.0, target net10.0 exclusively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Avoid re-parsing and re-sorting all package versions on every package update; check package presence directly against the raw XML elements instead
 - Reuse each NuGet source's SourceRepository across package lookups instead of rebuilding it per package, restoring NuGet's resource and HTTP caching.
 - SDK - Updated DotNet SDK to 10.0.302
+- Drop support for .NET 9.0; target .NET 10.0 exclusively
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Package.Tests/Credfeto.Package.Tests.csproj
+++ b/src/Credfeto.Package.Tests/Credfeto.Package.Tests.csproj
@@ -27,7 +27,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj
+++ b/src/Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj
@@ -27,7 +27,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Package.Update/Credfeto.Package.Update.csproj
+++ b/src/Credfeto.Package.Update/Credfeto.Package.Update.csproj
@@ -46,7 +46,7 @@
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>updatepackages</ToolCommandName>

--- a/src/Credfeto.Package/Credfeto.Package.csproj
+++ b/src/Credfeto.Package/Credfeto.Package.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/UpdatePackages</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

- Every `.csproj` multi-targeting `net9.0;net10.0` now targets `net10.0` only:
  - `src/Credfeto.Package/Credfeto.Package.csproj`
  - `src/Credfeto.Package.Update/Credfeto.Package.Update.csproj`
  - `src/Credfeto.Package.Tests/Credfeto.Package.Tests.csproj`
  - `src/Credfeto.Package.Update.Tests/Credfeto.Package.Update.Tests.csproj`
- Checked for and found none of: net9.0-specific MSBuild `Condition`s, `#if NET9_0` (non-`_OR_GREATER`) guards, `global.json` net9 pinning (already net10.0 SDK), or CI workflow references to net9.0 - so no dead-code cleanup was needed beyond the TFM elements themselves.

Closes #591

## Test plan

- [x] `dotnet buildcheck -solution src/Credfeto.Package.Update.slnx` - no errors
- [x] `dotnet build src/Credfeto.Package.Update.slnx -c Release` - 0 warnings, 0 errors
- [x] `Credfeto.Package.Tests` - 103/103 passed (net10.0)
- [x] `Credfeto.Package.Update.Tests` - 118/118 passed (net10.0)