### PR TITLE
perf: probe cache dictionary directly in PackageCache.GetVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Reuse each NuGet source's SourceRepository across package lookups instead of rebuilding it per package, restoring NuGet's resource and HTTP caching.
 - SDK - Updated DotNet SDK to 10.0.302
 - Drop support for .NET 9.0; target .NET 10.0 exclusively
+- Improve performance of PackageCache.GetVersions by probing the cache dictionary directly instead of scanning it for every requested package id
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
@@ -122,6 +122,20 @@ public sealed class PackageCacheTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public void GetVersions_WithDuplicateAndCaseVariantIds_ReturnsEachMatchOnce()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion packageVersion = new(packageId: "Test.Package", version: new NuGetVersion("1.0.0"));
+
+        cache.SetVersions([packageVersion]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetVersions(["Test.Package", "Test.Package", "test.package"]);
+
+        Assert.Single(result);
+        Assert.Equal(expected: "Test.Package", actual: result[0].PackageId);
+    }
+
+    [Fact]
     public void SetVersions_UpdatesExistingPackageWithHigherVersion()
     {
         PackageCache cache = this.CreateCache();

--- a/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
+++ b/src/Credfeto.Package.Tests/Services/PackageCacheTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Credfeto.Package.Services;
@@ -68,6 +69,56 @@ public sealed class PackageCacheTests : LoggingFolderCleanupTestBase
 
         Assert.Single(result);
         Assert.Equal(expected: "Test.Package", actual: result[0].PackageId);
+    }
+
+    [Fact]
+    public void GetVersions_WithMixOfKnownAndUnknownIds_ReturnsOnlyKnownMatches()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion packageVersion = new(packageId: "Test.Package", version: new NuGetVersion("1.0.0"));
+
+        cache.SetVersions([packageVersion]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetVersions(["Test.Package", "Unknown.Package"]);
+
+        Assert.Single(result);
+        Assert.Equal(expected: "Test.Package", actual: result[0].PackageId);
+    }
+
+    [Fact]
+    public void GetVersions_WithOnlyUnknownIds_ReturnsEmptyList()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion packageVersion = new(packageId: "Test.Package", version: new NuGetVersion("1.0.0"));
+
+        cache.SetVersions([packageVersion]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetVersions(["Unknown.Package"]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetVersions_WithMultiplePackagesCached_ReturnsOnlyRequestedSubset()
+    {
+        PackageCache cache = this.CreateCache();
+        PackageVersion first = new(packageId: "First.Package", version: new NuGetVersion("1.0.0"));
+        PackageVersion second = new(packageId: "Second.Package", version: new NuGetVersion("2.0.0"));
+        PackageVersion third = new(packageId: "Third.Package", version: new NuGetVersion("3.0.0"));
+
+        cache.SetVersions([first, second, third]);
+
+        IReadOnlyList<PackageVersion> result = cache.GetVersions(["Third.Package", "First.Package"]);
+
+        Assert.Equal(expected: 2, actual: result.Count);
+        Assert.Contains(
+            result,
+            p => StringComparer.Ordinal.Equals(p.PackageId, "First.Package") && p.Version == new NuGetVersion("1.0.0")
+        );
+        Assert.Contains(
+            result,
+            p => StringComparer.Ordinal.Equals(p.PackageId, "Third.Package") && p.Version == new NuGetVersion("3.0.0")
+        );
     }
 
     [Fact]

--- a/src/Credfeto.Package/Services/PackageCache.cs
+++ b/src/Credfeto.Package/Services/PackageCache.cs
@@ -91,9 +91,17 @@ public sealed class PackageCache : IPackageCache
 
     public IReadOnlyList<PackageVersion> GetVersions(IReadOnlyList<string> packageIds)
     {
-        return BuildVersions(
-            this._cache.Where(x => packageIds.Contains(value: x.Key, comparer: StringComparer.OrdinalIgnoreCase))
-        );
+        List<PackageVersion> found = new(packageIds.Count);
+
+        foreach (string packageId in packageIds)
+        {
+            if (this._cache.TryGetValue(key: packageId, out PackageVersion? version))
+            {
+                found.Add(version);
+            }
+        }
+
+        return found;
     }
 
     public void SetVersions(IReadOnlyList<PackageVersion> matching)

--- a/src/Credfeto.Package/Services/PackageCache.cs
+++ b/src/Credfeto.Package/Services/PackageCache.cs
@@ -86,7 +86,7 @@ public sealed class PackageCache : IPackageCache
 
     public IReadOnlyList<PackageVersion> GetAll()
     {
-        return BuildVersions(this._cache);
+        return [.. this._cache.Select(x => x.Value)];
     }
 
     public IReadOnlyList<PackageVersion> GetVersions(IReadOnlyList<string> packageIds)
@@ -116,11 +116,6 @@ public sealed class PackageCache : IPackageCache
     {
         this._changed = true;
         this._cache.Clear();
-    }
-
-    private static IReadOnlyList<PackageVersion> BuildVersions(IEnumerable<KeyValuePair<string, PackageVersion>> source)
-    {
-        return [.. source.Select(x => x.Value)];
     }
 
     [DoesNotReturn]

--- a/src/Credfeto.Package/Services/PackageCache.cs
+++ b/src/Credfeto.Package/Services/PackageCache.cs
@@ -92,10 +92,11 @@ public sealed class PackageCache : IPackageCache
     public IReadOnlyList<PackageVersion> GetVersions(IReadOnlyList<string> packageIds)
     {
         List<PackageVersion> found = new(packageIds.Count);
+        HashSet<string> seen = new(packageIds.Count, StringComparer.OrdinalIgnoreCase);
 
         foreach (string packageId in packageIds)
         {
-            if (this._cache.TryGetValue(key: packageId, out PackageVersion? version))
+            if (seen.Add(packageId) && this._cache.TryGetValue(key: packageId, out PackageVersion? version))
             {
                 found.Add(version);
             }


### PR DESCRIPTION
## Summary

- `PackageCache.GetVersions` enumerated the entire cache and, for every entry, checked membership in the requested id list via `List.Contains` - O(cache size x requested ids) string comparisons, and inverted (scanning the cache instead of probing it for the ids actually asked for).
- Replaced with a loop over the requested ids that probes the `ConcurrentDictionary` directly via `TryGetValue` - O(requested ids), each an O(1) average-case hash lookup. The dictionary is already keyed with `StringComparer.OrdinalIgnoreCase`, so casing behaviour is unchanged.
- Added test coverage for: a mix of known/unknown requested ids, requesting only unknown ids, and requesting a subset of multiple cached packages.

Closes #576

## Test plan

- [x] `dotnet buildcheck -solution src/Credfeto.Package.Update.slnx` - no errors
- [x] `dotnet build src/Credfeto.Package.Update.slnx -c Release` - 0 warnings, 0 errors
- [x] `Credfeto.Package.Tests` - 106/106 passed (net10.0, includes 3 new `GetVersions` tests)
- [x] `Credfeto.Package.Update.Tests` - 118/118 passed (net10.0)